### PR TITLE
Require cryptography 1.1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ htmlcov/
 nosetests.xml
 coverage.xml
 *,cover
+.idea/
 
 # Translations
 *.mo

--- a/setup.py
+++ b/setup.py
@@ -42,5 +42,5 @@ setup(
                            exclude=['contrib', 'docs', 'tests*',
                                     'venv', 'example*', '*egg-info',
                                     '.gitignore']),
-    install_requires=['cryptography'],
+    install_requires=['cryptography>=1.1.2'],
 )


### PR DESCRIPTION
Require cryptography 1.1.2 to prevent https://github.com/pyca/cryptography/issues/2468
Fixes #4 