### PR TITLE
(ignore) Single Device key and JWS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ coverage*.xml
 *,cover
 coverage
 .idea/
+*junit.xml
 
 # Translations
 *.mo

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -150,15 +150,15 @@ def run_jwt_tasks(data_size, count):
 
     keypair = oneid.service.create_secret_key()
     data = {'d': base64.b64encode(os.urandom(data_size)).decode('utf-8')[:data_size]}
-    jwt = oneid.service.make_jwt(data, keypair)
+    jwt = oneid.jwts.make_jwt(data, keypair)
 
     with operations_timer(count, 'creates'):
         for _ in range(count):
-            oneid.service.make_jwt(data, keypair)
+            oneid.jwts.make_jwt(data, keypair)
 
     with operations_timer(count, 'verifies'):
         for _ in range(count):
-            if not oneid.service.verify_jwt(jwt, keypair):
+            if not oneid.jwts.verify_jwt(jwt, keypair):
                 raise RuntimeError('error verifying jwt')
 
 

--- a/docs/tutorials/hello-world.rst
+++ b/docs/tutorials/hello-world.rst
@@ -26,7 +26,7 @@ Now we can create our "hello world" message and sign it.
     signature = my_key.sign(message)
     print(signature)
 
-To verify the signature, we need to pass in the message and the signature back into the Token.
+To verify the signature, we need to pass in the message and the signature back into the Keypair.
 
 ..  code-block:: python
 
@@ -41,6 +41,3 @@ something else like ``hello universe``.
 
     # raises InvalidSignature
     my_key.verify('hello universe', signature)
-
-
-

--- a/src/oneid/__init__.py
+++ b/src/oneid/__init__.py
@@ -1,7 +1,8 @@
 from . import keychain
 from . import service
 from . import session
+from . import jwts
 from . import utils
 
 
-__all__ = (keychain, service, session, utils)
+__all__ = (keychain, service, session, jwts, utils)

--- a/src/oneid/exceptions.py
+++ b/src/oneid/exceptions.py
@@ -1,2 +1,31 @@
+
+from cryptography.exceptions import UnsupportedAlgorithm, InvalidSignature
+
+
 class InvalidAuthentication(Exception):
+    pass
+
+
+class InvalidFormatError(ValueError):
+    pass
+
+
+class InvalidAlgorithmError(UnsupportedAlgorithm):
+    def __init__(self, message="invalid 'alg' specified"):
+        super(InvalidAlgorithmError, self).__init__(message)
+
+
+class InvalidClaimsError(ValueError):
+    pass
+
+
+class InvalidKeyError(InvalidSignature):
+    pass
+
+
+class KeySignatureMismatch(InvalidSignature):
+    pass
+
+
+class InvalidSignatureError(InvalidSignature):
     pass

--- a/src/oneid/jwts.py
+++ b/src/oneid/jwts.py
@@ -1,0 +1,169 @@
+# -*- coding: utf-8 -*-
+
+"""
+Provides useful functions for dealing with JWTs
+
+Based on the `JWT <https://tools.ietf.org/html/rfc7519/>`_ IETF RFC.
+
+"""
+from __future__ import unicode_literals
+
+import json
+import re
+import time
+import logging
+
+from . import utils, exceptions
+
+logger = logging.getLogger(__name__)
+
+
+B64_URLSAFE_RE = '[0-9a-zA-Z-_]+'
+JWT_RE = r'^{b64}\.{b64}\.{b64}$'.format(b64=B64_URLSAFE_RE)
+
+MINIMAL_JWT_HEADER = {
+    'typ': 'JWT',
+    'alg': 'ES256',
+}
+MINIMAL_JWT_HEADER_JSON = json.dumps(MINIMAL_JWT_HEADER)
+MINIMAL_JWT_HEADER_B64 = utils.to_string(utils.base64url_encode(MINIMAL_JWT_HEADER_JSON))
+
+TOKEN_EXPIRATION_TIME_SEC = (1*60*60)  # one hour
+TOKEN_NOT_BEFORE_LEEWAY_SEC = (2*60)   # two minutes
+TOKEN_EXPIRATION_LEEWAY_SEC = (3)      # three seconds
+
+
+def make_jwt(raw_claims, keypair):
+    """
+    Convert claims into JWT
+
+    :param raw_claims: payload data that will be converted to json
+    :type raw_claims: dict
+    :param keypair: :py:class:`~oneid.keychain.Keypair` to sign the request
+    :return: JWT
+    """
+    if not isinstance(raw_claims, dict):
+        raise TypeError('dict required for claims, type=' + str(type(raw_claims)))
+
+    claims = _normalize_claims(raw_claims, keypair.identity)
+    claims_serialized = json.dumps(claims)
+    claims_b64 = utils.to_string(utils.base64url_encode(claims_serialized))
+
+    payload = '{header}.{claims}'.format(header=MINIMAL_JWT_HEADER_B64, claims=claims_b64)
+
+    signature = utils.to_string(keypair.sign(payload))
+
+    return '{payload}.{sig}'.format(payload=payload, sig=signature)
+
+
+def verify_jwt(jwt, keypair=None):
+    """
+    Convert a JWT back to it's claims, if validated by the :py:class:`~oneid.keychain.Keypair`
+
+    :param jwt: JWT to verify and convert
+    :type jwt: str or bytes
+    :param keypair: :py:class:`~oneid.keychain.Keypair` to verify the JWT
+    :type keypair: :py:class:`~oneid.keychain.Keypair`
+    :returns: claims
+    :rtype: dict
+    :raises :py:class:`InvalidFormatError`: if not a valid JWT
+    :raises :py:class:`InvalidAlgorithmError`: if unsupported algorithm specified
+    :raises :py:class:`InvalidClaimsError`: if missing or invalid claims, including expiration,
+        re-used nonce, etc.
+    :raises :py:class:`InvalidSignatureError`: if signature is not valid
+    """
+    jwt = utils.to_string(jwt)
+    if not re.match(JWT_RE, jwt):
+        logger.debug('Given JWT doesnt match pattern: %s', jwt)
+        raise exceptions.InvalidFormatError
+
+    try:
+        header_json, claims_json, signature = [utils.base64url_decode(p) for p in jwt.split('.')]
+    except:
+        logger.debug('invalid JWT, error splitting/decoding: %s', jwt, exc_info=True)
+        raise exceptions.InvalidFormatError
+
+    header = _verify_jose_header(utils.to_string(header_json))
+    claims = _verify_claims(utils.to_string(claims_json))
+
+    if keypair:
+        try:
+            keypair.verify(*(jwt.rsplit('.', 1)))
+        except:
+            logger.debug('invalid signature, header=%s, claims=%s', header, claims)
+            raise exceptions.InvalidSignatureError
+
+    return claims
+
+
+def _normalize_claims(raw_claims, issuer=None):
+    now = int(time.time())
+    claims = {
+        # Required claims, may be over-written by entries in raw_claims
+        'jti': utils.make_nonce(),
+        'nbf': now,
+        'exp': now + TOKEN_EXPIRATION_TIME_SEC,
+    }
+    if issuer:
+        claims['iss'] = issuer
+
+    claims.update(raw_claims)
+
+    return claims
+
+
+def _verify_jose_header(header_json, strict_jwt=True):
+    header = None
+    try:
+        header = json.loads(header_json)
+        logger.debug('parsed header, header=%s', header)
+    except ValueError:
+        logger.debug('invalid header, not valid json: %s', header_json)
+        raise exceptions.InvalidFormatError
+    except Exception:  # pragma: no cover
+        logger.debug('unknown error verifying header: %s', header, exc_info=True)
+        raise
+
+    if strict_jwt:
+        for key, value in MINIMAL_JWT_HEADER.items():
+            if key not in header or header.get(key, None) != value:
+                logger.debug('invalid header, missing or incorrect %s: %s', key, header)
+                raise exceptions.InvalidFormatError
+        if len(MINIMAL_JWT_HEADER) != len(header):
+            logger.debug('invalid header, extra elements: %s', header)
+            raise exceptions.InvalidFormatError
+    else:
+        if 'typ' not in header or header['typ'] not in ['JWT', 'JOSE', 'JOSE+JSON']:
+            logger.debug('invalid "typ" in header: %s', header)
+            raise exceptions.InvalidFormatError
+
+        if 'alg' not in header or header['alg'] != 'ES256':
+            logger.debug('invalid "alg" in header: %s', header)
+            raise exceptions.InvalidAlgorithmError
+
+    logger.debug('returning %s', header)
+    return header
+
+
+def _verify_claims(payload):
+    try:
+        claims = json.loads(payload)
+    except:
+        logger.debug('unknown error verifying payload: %s', payload, exc_info=True)
+        raise exceptions.InvalidFormatError
+
+    now = int(time.time())
+
+    if 'exp' in claims and (int(claims['exp']) + TOKEN_EXPIRATION_LEEWAY_SEC) < now:
+        logger.warning('Expired token, exp=%s, now=%s', claims['exp'], now)
+        raise exceptions.InvalidClaimsError
+
+    if 'nbf' in claims and (int(claims['nbf']) - TOKEN_NOT_BEFORE_LEEWAY_SEC) > now:
+        logger.warning('Early token, nbf=%s, now=%s', claims['nbf'], now)
+        raise exceptions.InvalidClaimsError
+
+    if 'jti' in claims and not utils.verify_and_burn_nonce(claims['jti']):
+        logger.warning('Invalid nonce: %s', claims['jti'])
+        raise exceptions.InvalidClaimsError
+
+    return claims

--- a/src/oneid/jwts.py
+++ b/src/oneid/jwts.py
@@ -1,13 +1,17 @@
 # -*- coding: utf-8 -*-
 
 """
-Provides useful functions for dealing with JWTs
+Provides useful functions for dealing with JWTs and JWSs
 
-Based on the `JWT <https://tools.ietf.org/html/rfc7519/>`_ IETF RFC.
+Based on the
+`JWT <https://tools.ietf.org/html/rfc7519/>`_ and
+`JWS <https://tools.ietf.org/html/rfc7515/>`_
+IETF RFCs.
 
 """
 from __future__ import unicode_literals
 
+import collections
 import json
 import re
 import time
@@ -19,15 +23,16 @@ logger = logging.getLogger(__name__)
 
 
 B64_URLSAFE_RE = '[0-9a-zA-Z-_]+'
-JWT_RE = r'^{b64}\.{b64}\.{b64}$'.format(b64=B64_URLSAFE_RE)
+COMPACT_JWS_RE = r'^{b64}\.{b64}\.{b64}$'.format(b64=B64_URLSAFE_RE)
 
 MINIMAL_JWT_HEADER = {
     'typ': 'JWT',
     'alg': 'ES256',
 }
-MINIMAL_JWT_HEADER_JSON = json.dumps(MINIMAL_JWT_HEADER)
-MINIMAL_JWT_HEADER_B64 = utils.to_string(utils.base64url_encode(MINIMAL_JWT_HEADER_JSON))
-
+MINIMAL_JSON_JWS_HEADER = {
+    'typ': 'JOSE+JSON',
+    'alg': 'ES256',
+}
 TOKEN_EXPIRATION_TIME_SEC = (1*60*60)  # one hour
 TOKEN_NOT_BEFORE_LEEWAY_SEC = (2*60)   # two minutes
 TOKEN_EXPIRATION_LEEWAY_SEC = (3)      # three seconds
@@ -49,7 +54,13 @@ def make_jwt(raw_claims, keypair):
     claims_serialized = json.dumps(claims)
     claims_b64 = utils.to_string(utils.base64url_encode(claims_serialized))
 
-    payload = '{header}.{claims}'.format(header=MINIMAL_JWT_HEADER_B64, claims=claims_b64)
+    header = {}
+    header.update(MINIMAL_JWT_HEADER)
+    if keypair.identity:
+        header['kid'] = keypair.identity
+    header_b64 = utils.to_string(utils.base64url_encode(json.dumps(header)))
+
+    payload = '{header}.{claims}'.format(header=header_b64, claims=claims_b64)
 
     signature = utils.to_string(keypair.sign(payload))
 
@@ -73,7 +84,7 @@ def verify_jwt(jwt, keypair=None):
     :raises :py:class:`InvalidSignatureError`: if signature is not valid
     """
     jwt = utils.to_string(jwt)
-    if not re.match(JWT_RE, jwt):
+    if not re.match(COMPACT_JWS_RE, jwt):
         logger.debug('Given JWT doesnt match pattern: %s', jwt)
         raise exceptions.InvalidFormatError
 
@@ -96,6 +107,161 @@ def verify_jwt(jwt, keypair=None):
     return claims
 
 
+def make_jws(raw_claims, keypairs):
+    """
+    Convert claims into JWS format (compact or JSON)
+
+    :param raw_claims: payload data that will be converted to json
+    :type raw_claims: dict
+    :param keypairs: :py:class:`~oneid.keychain.Keypair`s to sign the request with
+    :type keypairs: list
+    :return: JWS
+    """
+    claims = _normalize_claims(raw_claims)
+    claims_serialized = json.dumps(claims)
+    claims_b64 = utils.to_string(utils.base64url_encode(claims_serialized))
+
+    ret = {
+        "payload": claims_b64,
+        "signatures": [],
+    }
+
+    if not isinstance(keypairs, collections.Iterable):
+        keypairs = [keypairs]
+
+    for keypair in keypairs:
+        if not keypair.identity:
+            logger.debug('Missing Keypair.identity')
+            raise exceptions.InvalidKeyError
+
+        header = {
+            'kid': keypair.identity,
+        }
+        header.update(MINIMAL_JSON_JWS_HEADER)
+        header_b64 = utils.to_string(utils.base64url_encode(json.dumps(header)))
+        to_sign = '{header}.{claims}'.format(header=header_b64, claims=claims_b64)
+
+        signature = utils.to_string(keypair.sign(to_sign))
+
+        ret['signatures'].append({
+            'protected': header_b64,
+            'signature': signature,
+        })
+
+    return json.dumps(ret)
+
+
+def extend_jws_signatures(jws, keypairs, default_jwt_kid=None):
+    """
+    Add signatures to an existing JWS (or JWT)
+
+    :param jws: existing JWS (Compact or JSON) or JWT
+    :type jws: str
+    :param keypairs: additional :py:class:`~oneid.keychain.Keypair`s to sign the request with
+    :type keypairs: list
+    :param default_jwt_kid: (optional) value for 'kid' header field if passing a JWT without one
+    :type default_jwt_kid: str
+    :return: JWS
+    """
+    ret = _jws_as_dict(jws, default_jwt_kid)
+    payload = ret['payload']
+
+    if not isinstance(keypairs, collections.Iterable):
+        keypairs = [keypairs]
+
+    for keypair in keypairs:
+        if not keypair.identity:
+            logger.debug('Missing Keypair.identity')
+            raise exceptions.InvalidKeyError
+
+        header = {
+            'kid': keypair.identity,
+        }
+        header.update(MINIMAL_JSON_JWS_HEADER)
+        header_b64 = utils.to_string(utils.base64url_encode(json.dumps(header)))
+        to_sign = '{header}.{claims}'.format(header=header_b64, claims=payload)
+
+        signature = utils.to_string(keypair.sign(to_sign))
+
+        ret['signatures'].append({
+            'protected': header_b64,
+            'signature': signature,
+        })
+
+    return json.dumps(ret)
+
+
+def get_jws_key_ids(jws):
+    """
+    Extract the IDs of the keys used to sign a given JWS
+
+    :param jws: JWS to get key IDs from
+    :type jws: str or bytes
+    :returns: key IDs
+    :rtype: list
+    :raises :py:class:`InvalidFormatError`: if not a valid JWS
+    """
+    try:
+        jws = json.loads(utils.to_string(jws))
+    except:
+        logger.debug('error parsing JWS', exc_info=True)
+        raise exceptions.InvalidFormatError
+
+    return [_get_kid_for_signature(signature) for signature in jws['signatures']]
+
+
+def verify_jws(jws, keypairs=None, verify_all=True):
+    """
+    Convert a JWS back to it's claims, if validated by a set of
+    required :py:class:`~oneid.keychain.Keypair`s
+
+    :param jws: JWS to verify and convert
+    :type jws: str or bytes
+    :param keypairs: :py:class:`~oneid.keychain.Keypair`s to verify the JWS with.
+                    Must include one for each specified in the JWS headers' `kid` values.
+    :type keypairs: list of :py:class:`~oneid.keychain.Keypair`
+    :param verify_all: If True (default), all keypairs must validate a signature.
+                    If False, only one needs to.
+                    If any fail to validate, the JWS is still not validated.
+                    This allows the caller to send multiple keys that _might_ have
+                    corresponding signatures, without requiring that _all_ do.
+    :type verify_all: bool
+    :returns: claims
+    :rtype: dict
+    :raises :py:class:`InvalidFormatError`: if not a valid JWS
+    :raises :py:class:`InvalidAlgorithmError`: if unsupported algorithm specified
+    :raises :py:class:`InvalidClaimsError`: if missing or invalid claims, including expiration,
+        re-used nonce, etc.
+    :raises :py:class:`InvalidSignatureError`: if any relevant signature is not valid
+    """
+
+    if keypairs and not isinstance(keypairs, collections.Iterable):
+        keypairs = [keypairs]
+
+    jws = utils.to_string(jws)
+
+    if re.match(COMPACT_JWS_RE, jws):
+
+        if verify_all and keypairs and len(keypairs) != 1:
+            raise exceptions.InvalidSignatureError(
+                'Compact JWS found but multiple signatures required'
+            )
+
+        return verify_jwt(jws, keypairs and keypairs[0])
+
+    jws = json.loads(jws)
+
+    if 'payload' not in jws or 'signatures' not in jws:
+        raise exceptions.InvalidFormatError
+
+    claims = _verify_claims(utils.to_string(utils.base64url_decode(jws['payload'])))
+
+    if keypairs:
+        _verify_jws_signatures(jws, keypairs, verify_all)
+
+    return claims
+
+
 def _normalize_claims(raw_claims, issuer=None):
     now = int(time.time())
     claims = {
@@ -112,6 +278,37 @@ def _normalize_claims(raw_claims, issuer=None):
     return claims
 
 
+def _jws_as_dict(jws, kid=None):
+
+    if not re.match(COMPACT_JWS_RE, jws):
+        return json.loads(jws)
+
+    header_b64, payload, signature = utils.to_string(jws).split('.')
+
+    header = json.loads(utils.to_string(utils.base64url_decode(header_b64)))
+    extra_header = None
+
+    if 'kid' not in header:
+        claims = json.loads(utils.to_string(utils.base64url_decode(payload)))
+        kid = kid or claims.get('iss')
+        extra_header = kid and {
+            'kid': kid
+        }
+
+    ret = {
+        'payload': payload,
+        'signatures': [{
+            'protected': header_b64,
+            'signature': signature,
+        }]
+    }
+
+    if extra_header:
+        ret['signatures'][0]['header'] = extra_header
+
+    return ret
+
+
 def _verify_jose_header(header_json, strict_jwt=True):
     header = None
     try:
@@ -125,11 +322,15 @@ def _verify_jose_header(header_json, strict_jwt=True):
         raise
 
     if strict_jwt:
+        keys = {k: 1 for k in header}
         for key, value in MINIMAL_JWT_HEADER.items():
             if key not in header or header.get(key, None) != value:
                 logger.debug('invalid header, missing or incorrect %s: %s', key, header)
                 raise exceptions.InvalidFormatError
-        if len(MINIMAL_JWT_HEADER) != len(header):
+            keys.pop(key, None)
+        keys.pop('kid', None)
+
+        if len(keys) > 0:
             logger.debug('invalid header, extra elements: %s', header)
             raise exceptions.InvalidFormatError
     else:
@@ -167,3 +368,66 @@ def _verify_claims(payload):
         raise exceptions.InvalidClaimsError
 
     return claims
+
+
+def _verify_jws_signatures(jws, keypairs, verify_all):
+    if len(jws['signatures']) == 0:
+        logger.warning('No signatures found, rejecting')
+        raise exceptions.InvalidSignatureError
+
+    if verify_all and len(keypairs) != len(jws['signatures']):
+        raise exceptions.KeySignatureMismatch('number of keys doesn\'t match number of signatures')
+
+    keypair_map = {str(keypair.identity): keypair for keypair in keypairs}
+
+    if len(keypairs) != len(keypair_map):
+        raise exceptions.InvalidKeyError('redundant keypairs found, unable to verify')
+
+    found_sigs = [_get_kid_for_signature(sig) in keypair_map for sig in jws['signatures']]
+
+    # need at least one signature
+    if not any(found_sigs):
+        logger.warning('No keypairs had corresponding signatures, rejecting')
+        raise exceptions.KeySignatureMismatch
+
+    # or all
+    if verify_all and not all(found_sigs):
+        logger.warning('Not all keys have corresponding signatures, rejecting')
+        raise exceptions.KeySignatureMismatch
+
+    for signature in jws['signatures']:
+        kid = _get_kid_for_signature(signature)
+
+        if verify_all or kid in keypair_map:
+            _verify_jws_signature(jws['payload'], keypair_map.get(kid), signature)
+
+
+def _get_kid_for_signature(signature):
+    header = _get_signature_header(signature)
+    kid = header.get('kid', signature.get('header', {}).get('kid'))
+
+    if not kid:
+        logger.warning(
+            'invalid header in signature, missing "kid": %s', signature
+        )
+        raise exceptions.InvalidFormatError
+
+    return kid
+
+
+def _get_signature_header(signature):
+    # TODO: check for overlapping keys in `protected` and `header`, merge together
+    #       for now, we only look for `kid` in `header`, and only if it isn't in `protected`
+
+    return _verify_jose_header(
+        utils.to_string(utils.base64url_decode(signature['protected'])),
+        strict_jwt=False,
+    )
+
+
+def _verify_jws_signature(payload, keypair, signature):
+    try:
+        keypair.verify('.'.join([signature['protected'], payload]), signature['signature'])
+    except:
+        logger.debug('invalid signature', exc_info=True)
+        raise exceptions.InvalidSignatureError

--- a/src/oneid/keychain.py
+++ b/src/oneid/keychain.py
@@ -1,6 +1,6 @@
 
 """
-Token is short for key pair, used to sign and verify signatures
+A Keypair is used to sign and verify signatures
 
 Keys should be kept in a secure storage enclave.
 """
@@ -39,13 +39,13 @@ class Credentials(object):
     :ivar identity: UUID of the identity.
     :ivar keypair: :class:`~oneid.keychain.Keypair` instance.
     """
-    def __init__(self, uuid, keypair):
+    def __init__(self, identity, keypair):
         """
 
         :param identity: uuid of the entity
         :param keypair: :py:class:`~oneid.keychain.Keypair` instance
         """
-        self.id = uuid
+        self.id = identity
 
         if not isinstance(keypair, Keypair):
             raise ValueError('keypair must be a oneid.keychain.Keypair instance')
@@ -54,15 +54,15 @@ class Credentials(object):
 
 
 class ProjectCredentials(Credentials):
-    def __init__(self, uuid, keypair, encryption_key):
+    def __init__(self, project_id, keypair, encryption_key):
         """
         Adds an ecryption key
 
-        :param uuid: oneID project UUID
+        :param project_id: oneID project UUID
         :param keypair: :py:class:`~oneid.keychain.Keypair`
         :param encryption_key: AES key used to encrypt messages
         """
-        super(ProjectCredentials, self).__init__(uuid, keypair)
+        super(ProjectCredentials, self).__init__(project_id, keypair)
         self._encryption_key = encryption_key
 
     def encrypt(self, plain_text):
@@ -247,8 +247,7 @@ class Keypair(object):
         sig_s = unpack_bytes(sig_s_bin)
 
         sig = encode_dss_signature(sig_r, sig_s)
-        signer = self.public_key.verifier(sig,
-                                          ec.ECDSA(hashes.SHA256()))
+        signer = self.public_key.verifier(sig, ec.ECDSA(hashes.SHA256()))
         signer.update(utils.to_bytes(payload))
         return signer.verify()
 

--- a/src/oneid/session.py
+++ b/src/oneid/session.py
@@ -2,11 +2,14 @@ from __future__ import unicode_literals
 
 import os
 import yaml
-import json
+import logging
+
 from requests import request
 from codecs import open
 
-from . import service, jwts, utils, exceptions
+from . import service, jwts, exceptions
+
+logger = logging.getLogger(__name__)
 
 
 class SessionBase(object):
@@ -14,23 +17,20 @@ class SessionBase(object):
     Abstract Session Class
 
     :ivar identity_credentials: oneID identity :class:`~oneid.keychain.Credentials`
-    :ivar application_credentials: unique app credentials :class:`~oneid.keychain.Credentials`
     :ivar project_credentials: unique project credentials :class:`~oneid.keychain.Credentials`
     :ivar oneid_credentials: oneID project credentials :class:`~oneid.keychain.Credentials`
     """
-    def __init__(self, identity_credentials=None, application_credentials=None,
-                 project_credentials=None, oneid_credentials=None, config=None):
+    def __init__(self, identity_credentials=None, project_credentials=None,
+                 oneid_credentials=None, config=None):
         """
 
         :param identity_credentials: :py:class:`~oneid.keychain.Credentials`
-        :param application_credentials: :py:class:`~oneid.keychain.Credentials`
         :param project_credentials: :py:class:`~oneid.keychain.ProjectCredentials`
         :param oneid_credentials: :py:class:`~oneid.keychain.Credentials`
         :param config: Dictionary or configuration keyword arguments
         :return:
         """
         self.identity_credentials = identity_credentials
-        self.app_credentials = application_credentials
         self.project_credentials = project_credentials
         self.oneid_credentials = oneid_credentials
 
@@ -76,6 +76,11 @@ class SessionBase(object):
 
         req = request(http_method, url, headers=headers, data=body)
 
+        logger.debug(
+            'making http %s request to %s, headers=%s, data=%s, req=%s',
+            http_method, url, headers, body, req,
+        )
+
         # 403 is Forbidden, raise an error if this occurs
         if req.status_code == 403:
             raise exceptions.InvalidAuthentication()
@@ -110,10 +115,9 @@ class SessionBase(object):
 
 
 class DeviceSession(SessionBase):
-    def __init__(self, identity_credentials=None, application_credentials=None,
-                 project_credentials=None, oneid_credentials=None, config=None):
+    def __init__(self, identity_credentials=None, project_credentials=None,
+                 oneid_credentials=None, config=None):
         super(DeviceSession, self).__init__(identity_credentials,
-                                            application_credentials,
                                             project_credentials,
                                             oneid_credentials, config)
 
@@ -121,66 +125,34 @@ class DeviceSession(SessionBase):
         """
         Verify a message received from the server
 
-        :param message: JSON formatted message with two signatures
+        :param message: JSON formatted JWS with at least two signatures
         :param rekey_credentials: List of :class:`~oneid.keychain.Credential`
-        :return: verified message
-        :raises: oneid.exceptions.InvalidAuthentication
+        :return: verified message or False if not valid
         """
-        data = json.loads(message)
-        if not data.get('payload'):
-            raise KeyError('missing payload')
-        if not data.get('oneid_signature'):
-            raise KeyError('missing oneID Digital Signature')
-        if not data.get('project_signature') and not data.get('rekey_signatures'):
-            raise KeyError('missing project signature')
+        standard_keypairs = [
+            self.project_credentials.keypair,
+            self.oneid_credentials.keypair,
+        ]
 
-        # Verify the signatures
-        payload = data['payload'].encode('utf-8')
+        if rekey_credentials:
+            keypairs = [credentials.keypair for credentials in rekey_credentials]
 
-        oneid_sig = data['oneid_signature']
-
-        project_sig = data.get('project_signature')
-        rekey_sigs = data.get('rekey_signatures', list())
-
-        if project_sig:
-            self.project_credentials.keypair.verify(payload, project_sig)
-
-        elif len(rekey_sigs) == 3 and len(rekey_credentials) == 3:
-            if self._check_rekey_sigs(rekey_sigs, rekey_credentials, payload) != 3:
-                raise InvalidSignature('One or more signatures were invalid')
+            kids = jwts.get_jws_key_ids(message)
+            keypairs += [keypair for keypair in standard_keypairs if keypair.identity in kids]
         else:
-            raise InvalidSignature('Missing project signature')
+            keypairs = standard_keypairs
 
-        self.oneid_credentials.keypair.verify(payload, oneid_sig)
+        return jwts.verify_jws(message, keypairs)
 
-    def _check_rekey_sigs(self, sigs, credentials, payload):
-        valid_sig_count = 0
-        # Iterate over all the possible signature/credential permutations
-        for sig in sigs:
-            for cred in credentials:
-                try:
-                    cred.keypair.verify(payload, sig)
-                except InvalidSignature:
-                    pass
-                else:
-                    valid_sig_count += 1
-                    break
-        return valid_sig_count
-
-    def prepare_message(self, **kwargs):
+    def prepare_message(self, *args, **kwargs):
         """
         Prepare a message before sending
 
-        :return: JSON with JWT payload and two signatures
+        :return: Signed JWT
         """
         kwargs['iss'] = self.identity_credentials.id
-        payload = self.create_jwt_payload(**kwargs)
-        identity_sig = utils.to_string(self.identity_credentials.keypair.sign(payload))
-        app_sig = utils.to_string(self.app_credentials.keypair.sign(payload))
 
-        return json.dumps({'payload': payload,
-                           'id_signature': identity_sig,
-                           'app_signature': app_sig})
+        return jwts.make_jws(kwargs, self.identity_credentials.keypair)
 
     def send_message(self, *args, **kwargs):
         raise NotImplementedError
@@ -190,10 +162,9 @@ class ServerSession(SessionBase):
     """
     Enable Server to request two-factor Authentication from oneID
     """
-    def __init__(self, identity_credentials=None, application_credentials=None,
-                 project_credentials=None, oneid_credentials=None, config=None):
+    def __init__(self, identity_credentials=None, project_credentials=None,
+                 oneid_credentials=None, config=None):
         super(ServerSession, self).__init__(identity_credentials,
-                                            application_credentials,
                                             project_credentials,
                                             oneid_credentials, config)
 
@@ -218,37 +189,27 @@ class ServerSession(SessionBase):
 
         super(ServerSession, self)._create_services(params, **global_kwargs)
 
-    def prepare_message(self, *args, **kwargs):
+    def prepare_message(self, oneid_response='', rekey_credentials=None):
         """
         Build message that has two-factor signatures
 
-        :param kwargs: oneid_response to parse and optionally rekey_credentials.
+        :param oneid_response: oneID-cosigned JWS to parse
+        :type oneid_response: str
+        :param rekey_credentials: (optional) rekey credentials
+        :type rekey_credentials: list
         :return: Content to be sent to devices
         """
         if self.project_credentials is None:
             raise AttributeError
 
-        oneid_response = kwargs.pop('oneid_response')
-        # split the JWT Token
-        alg, claims, oneid_sig = oneid_response.split('.')
-        payload = '{alg}.{claims}'.format(alg=alg, claims=claims)
+        keypairs = [
+            self.project_credentials.keypair  # just in case. oneID should include it's sig as sent
+        ]
 
-        reset_credentials = kwargs.get('rekey_credentials', list())
-        if len(reset_credentials) == 3:
-            reset_sigs = list()
-            for cred in reset_credentials:
-                sig = utils.to_string(cred.keypair.sign(payload))
-                reset_sigs.append(sig)
+        if rekey_credentials:
+            keypairs += [credentials.keypair for credentials in rekey_credentials]
 
-            return json.dumps({'payload': payload,
-                               'oneid_signature': oneid_sig,
-                               'reset_signatures': reset_sigs})
-
-        project_sig = utils.to_string(self.project_credentials.keypair.sign(payload))
-
-        return json.dumps({'payload': payload,
-                           'project_signature': project_sig,
-                           'oneid_signature': oneid_sig})
+        return jwts.extend_jws_signatures(oneid_response, keypairs)
 
     def send_message(self, *args, **kwargs):
         raise NotImplementedError
@@ -263,10 +224,9 @@ class AdminSession(SessionBase):
     They only need an identity_credentials and oneid_credentials
     to verify responses
     """
-    def __init__(self, identity_credentials, application_credentials=None,
-                 project_credentials=None, oneid_credentials=None, config=None):
+    def __init__(self, identity_credentials, project_credentials=None,
+                 oneid_credentials=None, config=None):
         super(AdminSession, self).__init__(identity_credentials,
-                                           application_credentials,
                                            project_credentials,
                                            oneid_credentials, config)
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -106,12 +106,6 @@ class TestBaseService(unittest.TestCase):
         edata = service.encrypt_attr_value(data, key)
         self.assertEqual(service.decrypt_attr_value(edata, key), data)
 
-    def test_jwt(self):
-        keypair = service.create_secret_key()
-        data = {'d': 'Hello, Im Data'}
-        jwt = service.make_jwt(data, keypair)
-        self.assertEqual(service.verify_jwt(jwt, keypair), data)
-
 
 class TestCreateSecretKey(unittest.TestCase):
     def test_basic_call(self):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -7,7 +7,7 @@ import sure  # noqa
 
 from cryptography.exceptions import InvalidSignature
 
-from oneid import session, service, keychain, exceptions
+from oneid import session, service, keychain, jwts, exceptions
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,4 +1,4 @@
-import json
+
 import logging
 
 import unittest
@@ -114,241 +114,173 @@ class TestBaseSession(unittest.TestCase):
 
 class TestDeviceSession(unittest.TestCase):
     def setUp(self):
-        mock_id_keypair = keychain.Keypair.from_secret_pem(key_bytes=TestSession.id_key_bytes)
-        self.id_credentials = keychain.Credentials('device-id', mock_id_keypair)
+        self.mock_id_keypair = keychain.Keypair.from_secret_pem(
+            key_bytes=TestSession.id_key_bytes
+        )
+        self.mock_id_keypair.identity = 'device-id'
 
-        mock_app_keypair = keychain.Keypair.from_secret_pem(key_bytes=TestSession.app_key_bytes)
-        self.app_credentials = keychain.Credentials('device-id', mock_app_keypair)
+        self.id_credentials = keychain.Credentials(
+            self.mock_id_keypair.identity,
+            self.mock_id_keypair
+        )
 
-        mock_proj_keypair = keychain.Keypair.from_secret_pem(key_bytes=TestSession.proj_key_bytes)
-        self.proj_credentials = keychain.Credentials('proj-id', mock_proj_keypair)
+        self.mock_proj_keypair = keychain.Keypair.from_secret_pem(
+            key_bytes=TestSession.proj_key_bytes
+        )
+        self.mock_proj_keypair.identity = 'proj-id'
 
-        mock_oneid_keypair = keychain.Keypair.from_secret_pem(key_bytes=TestSession.oneid_key_bytes)
-        self.oneid_credentials = keychain.Credentials('oneid-id', mock_oneid_keypair)
+        self.proj_credentials = keychain.Credentials(
+            self.mock_proj_keypair.identity,
+            self.mock_proj_keypair
+        )
 
-        mock_resetA_keypair = keychain.Keypair.from_secret_pem(
+        self.mock_oneid_keypair = keychain.Keypair.from_secret_pem(
+            key_bytes=TestSession.oneid_key_bytes
+        )
+        self.mock_oneid_keypair.identity = 'oneid-id'
+
+        self.oneid_credentials = keychain.Credentials(
+            self.mock_oneid_keypair.identity,
+            self.mock_oneid_keypair
+        )
+
+        self.mock_resetA_keypair = keychain.Keypair.from_secret_pem(
             key_bytes=TestSession.reset_key_A_bytes
         )
-        self.resetA_credentials = keychain.Credentials('resetA-id', mock_resetA_keypair)
+        self.mock_resetA_keypair.identity = 'resetA-id'
 
-        mock_resetB_keypair = keychain.Keypair.from_secret_pem(
+        self.resetA_credentials = keychain.Credentials(
+            self.mock_resetA_keypair.identity,
+            self.mock_resetA_keypair
+        )
+
+        self.mock_resetB_keypair = keychain.Keypair.from_secret_pem(
             key_bytes=TestSession.reset_key_B_bytes
         )
-        self.resetB_credentials = keychain.Credentials('resetB-id', mock_resetB_keypair)
+        self.mock_resetB_keypair.identity = 'resetB-id'
 
-        mock_resetC_keypair = keychain.Keypair.from_secret_pem(
+        self.resetB_credentials = keychain.Credentials(
+            self.mock_resetB_keypair.identity,
+            self.mock_resetB_keypair
+        )
+
+        self.mock_resetC_keypair = keychain.Keypair.from_secret_pem(
             key_bytes=TestSession.reset_key_C_bytes
         )
-        self.resetC_credentials = keychain.Credentials('resetC-id', mock_resetC_keypair)
+        self.mock_resetC_keypair.identity = 'resetC-id'
+
+        self.resetC_credentials = keychain.Credentials(
+            self.mock_resetC_keypair.identity,
+            self.mock_resetC_keypair
+        )
 
     def test_prepare_message(self):
-        sess = session.DeviceSession(self.id_credentials,
-                                     application_credentials=self.app_credentials)
-        message = sess.prepare_message()
+        sess = session.DeviceSession(self.id_credentials)
+        jws = sess.prepare_message(a=1)
 
-        self.assertIn('payload', message)
-        self.assertIn('app_signature', message)
-        self.assertIn('id_signature', message)
+        claims = jwts.verify_jws(jws, self.id_credentials.keypair)
 
-    def test_verify_missing_signature(self):
-        message_a = {'payload': 'eyJhbGciOiAiRVMyNTYiLCAidHlwIjogIkpXVCJ9.eyJ'
-                                'pc3MiOiAib25laWQiLCAianRpIjogIjAwMTIwMTYtMDE'
-                                'tMjBUMDA6NDU6MzhabjlxSGN5In0=',
-                     'oneid_signature': '299qez5eIY1C0qC7GAYDN87LKxkMlQX_r1ESL3'
-                                        'eFIbWkoY_hvWOZKrBkynyzetCbWHTZyb1yHp9B'
-                                        '_7gUPIwmBQ'}
+        claims.should.be.a(dict)
+        claims.should.have.key('a').equal_to(1)
 
-        message_b = {'payload': 'eyJhbGciOiAiRVMyNTYiLCAidHlwIjogIkpXVCJ9.eyJ'
-                                'pc3MiOiAib25laWQiLCAianRpIjogIjAwMTIwMTYtMDE'
-                                'tMjBUMDA6NDU6MzhabjlxSGN5In0=',
-                     'project_signature': 'b2z26vlRRpgVXl8UpgAl0x28zdHkrdkcJG'
-                                          'JNoC24NdGx5hFPo9PQqx7kW0Qh-4dTgb_B'
-                                          'GGHWrwy_6KWMKv8ZkA'}
+    def test_verify_message(self):
+        message = jwts.make_jws({'b': 2}, [self.mock_proj_keypair, self.mock_oneid_keypair])
 
-        sess = session.DeviceSession(self.id_credentials,
-                                     application_credentials=self.app_credentials)
+        sess = session.DeviceSession(
+            self.id_credentials, self.proj_credentials, self.oneid_credentials
+        )
 
-        self.assertRaises(KeyError, sess.verify_message, json.dumps(message_a))
-        self.assertRaises(KeyError, sess.verify_message, json.dumps(message_b))
+        claims = sess.verify_message(message)
 
-    def test_verify_missing_payload(self):
-        message = {'project_signature': 'b2z26vlRRpgVXl8UpgAl0x28zdHkrdkcJG'
-                                        'JNoC24NdGx5hFPo9PQqx7kW0Qh-4dTgb_B'
-                                        'GGHWrwy_6KWMKv8ZkA',
-                   'oneid_signature': '299qez5eIY1C0qC7GAYDN87LKxkMlQX_r1ESL3'
-                                      'eFIbWkoY_hvWOZKrBkynyzetCbWHTZyb1yHp9B'
-                                      '_7gUPIwmBQ'}
+        claims.should.be.a(dict)
+        claims.should.have.key('b').equal_to(2)
 
-        sess = session.DeviceSession(self.id_credentials,
-                                     application_credentials=self.app_credentials)
+    def test_verify_message_with_rekey(self):
+        message = jwts.make_jws({'c': 3}, [
+            self.mock_proj_keypair, self.mock_oneid_keypair,
+            self.mock_resetA_keypair,
+            self.mock_resetB_keypair,
+            self.mock_resetC_keypair,
+        ])
 
-        self.assertRaises(KeyError, sess.verify_message, json.dumps(message))
+        sess = session.DeviceSession(
+            self.id_credentials, self.proj_credentials, self.oneid_credentials,
+        )
 
-    def test_verify_project_signature(self):
-        message = {'payload': 'eyJhbGciOiAiRVMyNTYiLCAidHlwIjogIkpXVCJ9.eyJ'
-                              'pc3MiOiAib25laWQiLCAianRpIjogIjAwMTIwMTYtMDE'
-                              'tMjBUMDA6NDU6MzhabjlxSGN5In0=',
-                   'project_signature': 'b2z26vlRRpgVXl8UpgAl0x28zdHkrdkcJG'
-                                        'JNoC24NdGx5hFPo9PQqx7kW0Qh-4dTgb_B'
-                                        'GGHWrwy_6KWMKv8ZkA',
-                   'oneid_signature': '299qez5eIY1C0qC7GAYDN87LKxkMlQX_r1ESL3'
-                                      'eFIbWkoY_hvWOZKrBkynyzetCbWHTZyb1yHp9B'
-                                      '_7gUPIwmBQ'}
-        data = json.dumps(message)
-        sess = session.DeviceSession(self.id_credentials,
-                                     application_credentials=self.app_credentials,
-                                     oneid_credentials=self.oneid_credentials,
-                                     project_credentials=self.proj_credentials)
-        sess.verify_message(data)
+        claims = sess.verify_message(message, rekey_credentials=[
+            self.resetA_credentials,
+            self.resetB_credentials,
+            self.resetC_credentials,
+        ])
 
-    def test_verify_rekey_signatures(self):
-        message = {'payload': 'eyJhbGciOiAiRVMyNTYiLCAidHlwIjogIkpXVCJ9.eyJ'
-                              'pc3MiOiAib25laWQiLCAianRpIjogIjAwMTIwMTYtMDE'
-                              'tMjBUMDA6NDU6MzhabjlxSGN5In0=',
-                   'oneid_signature': '299qez5eIY1C0qC7GAYDN87LKxkMlQX_r1ESL3'
-                                      'eFIbWkoY_hvWOZKrBkynyzetCbWHTZyb1yHp9B'
-                                      '_7gUPIwmBQ',
-                   'rekey_signatures': ['X7z82ZQ0y1zC6w2x-vK4Aq1JwS4RwA3utwcb'
-                                        '7vIktEVXbd1e_4QAkJc3g1f00KlajIbZnvDd'
-                                        'r4lKsePIR6s-VA',
-                                        'YpbbBekxE-TvNwDpDI9sgzXt_iPFP9YAvfPa'
-                                        '-tf9v89ETQ-hDX0RnIZ-1Le4HfQXL-i4ij10'
-                                        'Y6VrQoLzN_Vesg',
-                                        'JAMqXv1QLWmMDPThcG-wXDml4K436gqzHYOQ'
-                                        'TkFtb5s6hdX3SuqMgijcQjuzUW6VU8K_8VGpm'
-                                        'C0yiDZKSPUXtQ',
-                                        ]
+        claims.should.be.a(dict)
+        claims.should.have.key('c').equal_to(3)
 
-                   }
-        data = json.dumps(message)
-        sess = session.DeviceSession(self.id_credentials,
-                                     application_credentials=self.app_credentials,
-                                     oneid_credentials=self.oneid_credentials,
-                                     project_credentials=self.proj_credentials)
+    def test_verify_message_with_rekey_keys_only(self):
+        message = jwts.make_jws({'c': 4}, [
+            self.mock_resetA_keypair,
+            self.mock_resetB_keypair,
+            self.mock_resetC_keypair,
+        ])
 
-        sess.verify_message(data, rekey_credentials=[self.resetA_credentials,
-                                                     self.resetB_credentials,
-                                                     self.resetC_credentials])
+        sess = session.DeviceSession(
+            self.id_credentials, self.proj_credentials, self.oneid_credentials,
+        )
 
-    def test_invalid_rekey_signature(self):
-        message = {'payload': 'eyJhbGciOiAiRVMyNTYiLCAidHlwIjogIkpXVCJ9.eyJ'
-                              'pc3MiOiAib25laWQiLCAianRpIjogIjAwMTIwMTYtMDE'
-                              'tMjBUMDA6NDU6MzhabjlxSGN5In0=',
-                   'oneid_signature': '299qez5eIY1C0qC7GAYDN87LKxkMlQX_r1ESL3'
-                                      'eFIbWkoY_hvWOZKrBkynyzetCbWHTZyb1yHp9B'
-                                      '_7gUPIwmBQ',
-                   'rekey_signatures': ['JAMqXv1QLWmMDPThcG-wXDml4K436gqzHYOQ'
-                                        'TkFtb5s6hdX3SuqMgijcQjuzUW6VU8K_8VGp'
-                                        'mC0yiDZKSPUXtQ',
-                                        'qj0IBKcJTiqBTxoP193wZ5hkwgaCDnLswSBB'
-                                        'sYXwQ0iOISmofCeZBYA_ZEo-F2k5AbBrvGBu'
-                                        'ErG4FhkeQELYZw',
-                                        'YpbbBekxE-TvNwDpDI9sgzXt_iPFP9YAvfPa'
-                                        '-tf9v89ETQ-hDX0RnIZ-1Le4HfQXL-i4ij10'
-                                        'Y6VrQoLzN_Vesg',
-                                        ]
+        claims = sess.verify_message(message, rekey_credentials=[
+            self.resetA_credentials,
+            self.resetB_credentials,
+            self.resetC_credentials,
+        ])
 
-                   }
-
-        sess = session.DeviceSession(self.id_credentials,
-                                     application_credentials=self.app_credentials,
-                                     oneid_credentials=self.oneid_credentials,
-                                     project_credentials=self.proj_credentials)
-
-        self.assertRaises(InvalidSignature, sess.verify_message, json.dumps(message),
-                          rekey_credentials=[self.resetA_credentials,
-                                             self.resetB_credentials,
-                                             self.resetC_credentials])
-
-    def test_missing_rekey_signature(self):
-        message = {'payload': 'eyJhbGciOiAiRVMyNTYiLCAidHlwIjogIkpXVCJ9.eyJ'
-                              'pc3MiOiAib25laWQiLCAianRpIjogIjAwMTIwMTYtMDE'
-                              'tMjBUMDA6NDU6MzhabjlxSGN5In0=',
-                   'oneid_signature': '299qez5eIY1C0qC7GAYDN87LKxkMlQX_r1ESL3'
-                                      'eFIbWkoY_hvWOZKrBkynyzetCbWHTZyb1yHp9B'
-                                      '_7gUPIwmBQ',
-                   'rekey_signatures': ['X7z82ZQ0y1zC6w2x-vK4Aq1JwS4RwA3utwcb'
-                                        '7vIktEVXbd1e_4QAkJc3g1f00KlajIbZnvDd'
-                                        'r4lKsePIR6s-VA',
-                                        'YpbbBekxE-TvNwDpDI9sgzXt_iPFP9YAvfPa'
-                                        '-tf9v89ETQ-hDX0RnIZ-1Le4HfQXL-i4ij10'
-                                        'Y6VrQoLzN_Vesg',
-                                        'JAMqXv1QLWmMDPThcG-wXDml4K436gqzHYOQ',
-                                        ]
-
-                   }
-
-        sess = session.DeviceSession(self.id_credentials,
-                                     application_credentials=self.app_credentials,
-                                     oneid_credentials=self.oneid_credentials,
-                                     project_credentials=self.proj_credentials)
-
-        self.assertRaises(InvalidSignature, sess.verify_message, json.dumps(message),
-                          rekey_credentials=[self.resetA_credentials,
-                                             self.resetB_credentials,
-                                             self.resetC_credentials])
-
-    def test_missing_rekey_credential(self):
-        message = {'payload': 'eyJhbGciOiAiRVMyNTYiLCAidHlwIjogIkpXVCJ9.eyJ'
-                              'pc3MiOiAib25laWQiLCAianRpIjogIjAwMTIwMTYtMDE'
-                              'tMjBUMDA6NDU6MzhabjlxSGN5In0=',
-                   'oneid_signature': '299qez5eIY1C0qC7GAYDN87LKxkMlQX_r1ESL3'
-                                      'eFIbWkoY_hvWOZKrBkynyzetCbWHTZyb1yHp9B'
-                                      '_7gUPIwmBQ',
-                   'rekey_signatures': ['X7z82ZQ0y1zC6w2x-vK4Aq1JwS4RwA3utwcb'
-                                        '7vIktEVXbd1e_4QAkJc3g1f00KlajIbZnvDd'
-                                        'r4lKsePIR6s-VA',
-                                        'YpbbBekxE-TvNwDpDI9sgzXt_iPFP9YAvfPa'
-                                        '-tf9v89ETQ-hDX0RnIZ-1Le4HfQXL-i4ij10'
-                                        'Y6VrQoLzN_Vesg',
-                                        'JAMqXv1QLWmMDPThcG-wXDml4K436gqzHYOQ'
-                                        'TkFtb5s6hdX3SuqMgijcQjuzUW6VU8K_8VGpm'
-                                        'C0yiDZKSPUXtQ',
-                                        ]
-
-                   }
-        sess = session.DeviceSession(self.id_credentials,
-                                     application_credentials=self.app_credentials,
-                                     oneid_credentials=self.oneid_credentials,
-                                     project_credentials=self.proj_credentials)
-
-        self.assertRaises(InvalidSignature, sess.verify_message, json.dumps(message),
-                          rekey_credentials=[self.resetA_credentials,
-                                             self.resetB_credentials])
+        claims.should.be.a(dict)
+        claims.should.have.key('c').equal_to(4)
 
 
 class TestServerSession(unittest.TestCase):
     def setUp(self):
         mock_keypair = keychain.Keypair.from_secret_pem(key_bytes=TestSession.id_key_bytes)
-        self.server_credentials = keychain.Credentials('server', mock_keypair)
+        mock_keypair.identity = 'server'
+        self.server_credentials = keychain.Credentials(mock_keypair.identity, mock_keypair)
 
         mock_oneid_keypair = keychain.Keypair.from_secret_pem(key_bytes=TestSession.oneid_key_bytes)
-        self.oneid_credentials = keychain.Credentials('oneID', mock_oneid_keypair)
+        mock_oneid_keypair.identity = 'oneID'
+        self.oneid_credentials = keychain.Credentials(
+            mock_oneid_keypair.identity, mock_oneid_keypair
+        )
 
         mock_project_keypair = keychain.Keypair.from_secret_pem(
             key_bytes=TestSession.proj_key_bytes
         )
-        self.project_credentials = keychain.Credentials('proj', mock_project_keypair)
+        mock_project_keypair.identity = 'proj'
+        self.project_credentials = keychain.Credentials(
+            mock_project_keypair.identity, mock_project_keypair
+        )
         mock_resetA_keypair = keychain.Keypair.from_secret_pem(
             key_bytes=TestSession.reset_key_A_bytes
         )
-        self.resetA_credentials = keychain.Credentials('resetA-id', mock_resetA_keypair)
+        mock_resetA_keypair.identity = 'resetA-id'
+        self.resetA_credentials = keychain.Credentials(
+            mock_resetA_keypair.identity, mock_resetA_keypair
+        )
 
         mock_resetB_keypair = keychain.Keypair.from_secret_pem(
             key_bytes=TestSession.reset_key_B_bytes
         )
-        self.resetB_credentials = keychain.Credentials('resetB-id', mock_resetB_keypair)
+        mock_resetB_keypair.identity = 'resetB-id'
+        self.resetB_credentials = keychain.Credentials(
+            mock_resetB_keypair.identity, mock_resetB_keypair
+        )
 
         mock_resetC_keypair = keychain.Keypair.from_secret_pem(
             key_bytes=TestSession.reset_key_C_bytes
         )
-        self.resetC_credentials = keychain.Credentials('resetC-id', mock_resetC_keypair)
+        mock_resetC_keypair.identity = 'resetC-id'
+        self.resetC_credentials = keychain.Credentials(
+            mock_resetC_keypair.identity, mock_resetC_keypair
+        )
 
-        self.oneid_response = 'eyJhbGciOiAiRVMyNTYiLCAidHlwIjogIkpXVCJ9.eyJpc3Mi' \
-                              'OiAib25lSUQiLCAianRpIjogIjAwMTIwMTYtMDEtMjBUMjE6N' \
-                              'TE6MDZabDJ5dHlXIn0=.eEhASqRrKWPhzKVmSmeFZY5tGeTgo' \
-                              'nZS45qwnz0_4VJb_qM_kNnQqLp96mPZLUtKHVIeJqA77SqlVx' \
-                              'WsOB1J4g'
+        self.oneid_response = jwts.make_jwt({'a': 1}, mock_oneid_keypair)  # TODO: JWS with both
 
         self.fake_config = {
             'GLOBAL': {
@@ -388,16 +320,11 @@ class TestServerSession(unittest.TestCase):
 
         authenticated_data = sess.prepare_message(oneid_response=self.oneid_response)
 
-        authenticated_msg = json.loads(authenticated_data)
-
-        self.assertIn('payload', authenticated_msg)
-        self.assertIn('project_signature', authenticated_msg)
-        self.assertIn('oneid_signature', authenticated_msg)
-
-        self.project_credentials.keypair.verify(authenticated_msg['payload'],
-                                                authenticated_msg['project_signature'])
-        self.oneid_credentials.keypair.verify(authenticated_msg['payload'],
-                                              authenticated_msg['oneid_signature'])
+        keypairs = [
+            self.oneid_credentials.keypair,
+            self.project_credentials.keypair,
+        ]
+        jwts.verify_jws(authenticated_data, keypairs).should.be.a(dict)
 
     def test_prepare_message_no_project(self):
         sess = session.ServerSession(identity_credentials=self.server_credentials,
@@ -418,22 +345,15 @@ class TestServerSession(unittest.TestCase):
                 self.resetC_credentials,
             ]
         )
-        msg = json.loads(authenticated_data)
 
-        msg.should.have.key('payload')
-        msg.should.have.key('oneid_signature')
-        msg.should.have.key('reset_signatures').being.a(list)
-
-        msg['reset_signatures'].should.have.length_of(3)
-
-        payload = msg['payload']
-        self.oneid_credentials.keypair.verify(payload, msg['oneid_signature']).should.be.true
-
-        reset_sigs = msg['reset_signatures']
-
-        self.resetA_credentials.keypair.verify(payload, reset_sigs[0]).should.be.true
-        self.resetB_credentials.keypair.verify(payload, reset_sigs[1]).should.be.true
-        self.resetC_credentials.keypair.verify(payload, reset_sigs[2]).should.be.true
+        keypairs = [
+            self.oneid_credentials.keypair,
+            self.project_credentials.keypair,
+            self.resetA_credentials.keypair,
+            self.resetB_credentials.keypair,
+            self.resetC_credentials.keypair,
+        ]
+        jwts.verify_jws(authenticated_data, keypairs).should.be.a(dict)
 
 
 class TestAdminSession(unittest.TestCase):


### PR DESCRIPTION
- Modified DeviceSession to use a single Credentials for both the Project and oneID
- Converted message format to use JWS
- Opportunistic refactoring and cleanups

**** replaced by https://github.com/OneID/oneID-connect-python/pull/36 ****