### PR TITLE
Simplified and expanded ServerSession

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [flake8]
-exclude = env,.git,__pycache__,build,docs
+exclude = env,.git,__pycache__,.tox,build,docs
 max-line-length = 100
 max-complexity = 10

--- a/src/oneid/service.py
+++ b/src/oneid/service.py
@@ -51,13 +51,20 @@ class ServiceCreator(object):
 
         methods = dict()
         for method_name, method_values in service_model.items():
-            required_jwt = list()
-            all_jwt = list()
+            required_jwt = []
+            all_jwt = []
+            required_url = []
+            all_url = []
+
             for arg_name, arg_properties in method_values['arguments'].items():
                 if arg_properties['location'] == 'jwt':
                     all_jwt.append(arg_name)
                     if arg_properties['required'] is True:
                         required_jwt.append(arg_name)
+                if arg_properties['location'] == 'url':
+                    all_url.append(arg_name)
+                    if arg_properties['required'] is True:
+                        required_url.append(arg_name)
 
             absolute_url = '{base}{endpoint}'.format(base=base_url,
                                                      endpoint=method_values['endpoint'])
@@ -67,12 +74,16 @@ class ServiceCreator(object):
                                                            method_values['method'],
                                                            all_body_args=all_jwt,
                                                            required_body_args=required_jwt,
+                                                           all_url_args=all_url,
+                                                           required_url_args=required_url,
                                                            )
         return methods
 
     def _create_api_method(self, name,
                            endpoint, http_method,
-                           all_body_args, required_body_args):
+                           all_body_args, required_body_args,
+                           all_url_args, required_url_args,
+                           ):
         """
         Add methods to session dynamically from yaml file
 
@@ -87,6 +98,9 @@ class ServiceCreator(object):
                         raise TypeError('Missing Required Keyword Argument:'
                                         ' %s' % required)
                 kwargs.update(body_args=all_body_args)
+            for required in required_url_args:
+                if required not in kwargs:
+                    raise TypeError('Missing Required URL Argument: %s' % required)
             return self._make_api_request(endpoint, http_method, **kwargs)
 
         _api_call.__name__ = str(name)

--- a/tests/test_jwts.py
+++ b/tests/test_jwts.py
@@ -458,6 +458,19 @@ class TestJWSs(TestCase):
         verified_msg = jwts.verify_jws(jws, self.keypairs)
         self.assertIsInstance(verified_msg, dict)
 
+    def test_remove_jws_signature(self):
+        jws = jwts.make_jws({'a': 1}, self.keypairs)
+        jws = jwts.remove_jws_signatures(jws, self.keypairs[0].identity)
+        verified_msg = jwts.verify_jws(jws, self.keypairs[1:])
+        self.assertIsInstance(verified_msg, dict)
+
+    def test_remove_jws_signature_list(self):
+        jws = jwts.make_jws({'a': 1}, self.keypairs)
+        ids = [keypair.identity for keypair in self.keypairs[:2]]
+        jws = jwts.remove_jws_signatures(jws, ids)
+        verified_msg = jwts.verify_jws(jws, self.keypairs[2:])
+        self.assertIsInstance(verified_msg, dict)
+
     def test_get_jws_key_ids(self):
         jws = jwts.make_jws({'a': 1}, self.keypairs)
         kids = [keypair.identity for keypair in self.keypairs]

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -38,6 +38,10 @@ class TestServiceCreator(unittest.TestCase):
                         'location': 'jwt',
                         'required': False,
                     },
+                    'optional_in_url': {
+                        'location': 'url',
+                        'required': False,
+                    },
                 },
             }
         }
@@ -73,14 +77,19 @@ class TestServiceCreator(unittest.TestCase):
         self.assertEqual(test_method, "tested")
 
     @mock.patch('oneid.session.request', side_effect=mock_request)
+    def test_call_created_method_with_body(self, mock_request):
+        test_method = self.service.test_method(body="hello", in_url='something')
+        self.assertEqual(test_method, "tested")
+
+    @mock.patch('oneid.session.request', side_effect=mock_request)
     def test_call_created_method_missing_args(self, mock_request):
         with self.assertRaises(TypeError):
             self.service.test_method()
 
     @mock.patch('oneid.session.request', side_effect=mock_request)
-    def test_call_created_method_with_body(self, mock_request):
-        test_method = self.service.test_method(body="hello")
-        self.assertEqual(test_method, "tested")
+    def test_call_created_method_with_body_missing_url_param(self, mock_request):
+        with self.assertRaises(TypeError):
+            self.service.test_method(body="hello")
 
 
 class TestBaseService(unittest.TestCase):


### PR DESCRIPTION
- `prepare_message` takes arbitrary named parameters to encode into JSON dictionary, or raw message
- Implemented `verify_message`, with optional oneID co-signing