### PR TITLE
Add JWE Support

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -170,5 +170,6 @@ def set_logging_level(debug_level):
                         format='%(asctime)-15s %(levelname)-8s [%(name)s:%(lineno)s] %(message)s'
                         )
 
+
 if __name__ == '__main__':
     main()

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -8,6 +8,7 @@ API
     service
     session
     jwts
+    jwes
     nonces
     auth
     utils

--- a/docs/api/jwes.rst
+++ b/docs/api/jwes.rst
@@ -1,0 +1,5 @@
+oneid.jwes
+==========
+
+.. automodule:: oneid.jwes
+   :members: make_jwe, decrypt_jwe

--- a/docs/api/nonces.rst
+++ b/docs/api/nonces.rst
@@ -1,5 +1,5 @@
 oneid.nonces
-===========
+============
 
 .. automodule:: oneid.nonces
    :members: make_nonce, set_nonce_handlers, verify_nonce, burn_nonce

--- a/src/oneid/__about__.py
+++ b/src/oneid/__about__.py
@@ -11,7 +11,7 @@ __summary__ = ("oneID-connect is an identity & authentication "
 
 __uri__ = "https://github.com/OneID/oneID-connect-python"
 
-__version__ = "0.16.0-alpha.0"
+__version__ = "0.17.0-alpha.1"
 
 __author__ = "oneID Inc."
 __email__ = "support@oneID.com"

--- a/src/oneid/__init__.py
+++ b/src/oneid/__init__.py
@@ -2,8 +2,9 @@ from . import keychain
 from . import service
 from . import session
 from . import jwts
+from . import jwes
 from . import nonces
 from . import utils
 
 
-__all__ = (keychain, service, session, jwts, nonces, utils)
+__all__ = (keychain, service, session, jwts, jwes, nonces, utils)

--- a/src/oneid/exceptions.py
+++ b/src/oneid/exceptions.py
@@ -42,3 +42,15 @@ class ReservedHeader(Exception):
 
 class InvalidSignatureIndexes(Exception):
     pass
+
+
+class IdentityRequired(ValueError):
+    pass
+
+
+class InvalidRecipient(Exception):
+    pass
+
+
+class DecryptionFailed(Exception):
+    pass

--- a/src/oneid/jose.py
+++ b/src/oneid/jose.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+
+import re
+import json
+import six
+import time
+import logging
+
+from datetime import datetime
+from dateutil import tz
+
+from . import nonces, utils
+
+logger = logging.getLogger(__name__)
+
+
+B64_URLSAFE_RE = '[0-9a-zA-Z-_]+'
+COMPACT_JWS_RE = r'^{b64}\.{b64}\.{b64}$'.format(b64=B64_URLSAFE_RE)
+
+
+TOKEN_EXPIRATION_TIME_SEC = nonces.DEFAULT_NONCE_EXPIRY_SECONDS
+
+
+def is_compact_jws(jws):
+    return bool(re.match(COMPACT_JWS_RE, jws))
+
+
+def is_jws(jws, json_decoder=json.loads):
+    REQUIRED_FIELDS = ['payload', 'signatures']
+
+    if isinstance(jws, six.string_types):
+        if is_compact_jws(jws):
+            return True
+        jws = json_decoder(jws)
+
+    if not isinstance(jws, dict):
+        return False
+
+    if not all([k in jws for k in REQUIRED_FIELDS]):
+        return False
+
+    return True
+
+
+def normalize_claims(raw_claims, issuer=None):
+    exp = None
+    nbf = None
+    nonce = None
+
+    exp = raw_claims.get('exp', exp)
+    nbf = raw_claims.get('nbf', nbf)
+    nonce = raw_claims.get('jti', nonce)
+    if not issuer:
+        issuer = raw_claims.get('iss')
+
+    if exp and not nonce:
+        # use message expiration for nonce expiration
+        exp_dt = datetime.fromtimestamp(exp, tz.tzutc())
+        nonce = nonces.make_nonce(exp_dt)
+    elif nonce and (nonce[:3] == '002') and not exp:
+        # use >v1 nonce expiration for message expiration
+        try:
+            exp = utils.to_timestamp(nonce[3:-6])
+        except:
+            logger.warning('unable to parse jti for nonce exp, using default, jti=%s', nonce)
+
+    now = int(time.time())
+    default_exp_ts = (now + TOKEN_EXPIRATION_TIME_SEC)
+    default_exp_dt = datetime.fromtimestamp(default_exp_ts, tz.tzutc())
+
+    claims = {
+        'jti': nonce or nonces.make_nonce(default_exp_dt),
+        'nbf': nbf or now,
+        'exp': exp or default_exp_ts,
+    }
+    if issuer:
+        claims['iss'] = issuer
+
+    claims.update(raw_claims)
+
+    return claims
+
+
+def as_dict(jose_obj, json_decoder=json.loads):
+
+    if not isinstance(jose_obj, dict):
+        jose_obj = json_decoder(utils.to_string(jose_obj))
+
+    return jose_obj

--- a/src/oneid/jwes.py
+++ b/src/oneid/jwes.py
@@ -1,0 +1,178 @@
+# -*- coding: utf-8 -*-
+
+"""
+Provides useful functions for dealing with JWEs
+
+Based on the
+`JSON Web Encryption (JWE) <https://tools.ietf.org/html/rfc7516/>`_, and
+`JSON Web Algorithms (JWA) <https://tools.ietf.org/html/rfc7518/>`_,
+IETF RFCs.
+
+"""
+from __future__ import unicode_literals
+
+import collections
+import json
+import base64
+import logging
+
+from . import jose, service, keychain, utils, exceptions
+
+logger = logging.getLogger(__name__)
+
+NON_OVERRIDABLE_CLAIMS = ['enc', 'alg', 'epk', 'apu']
+
+
+def make_jwe(raw_claims, sender_keypair, recipient_keypairs, jsonify=True, json_encoder=json.dumps):
+    """
+    Convert claims into a JWE with General JWE JSON Serialization syntax
+
+    :param raw_claims: payload data that will be converted to json
+    :type raw_claims: dict
+    :param recipient_keypairs: :py:class:`~oneid.keychain.Keypair`\s to encrypt the claims for
+    :type recipient_keypairs: list or :py:class:`~oneid.keychain.Keypair`
+    :param jsonify: If True (default), return JSON, otherwise keep as dict
+    :type jsonify: bool
+    :param json_encoder: encodes a :py:class:`dict` into JSON. Defaults to `json.dumps`
+    :type json_encoder: function
+    :return: JWE
+    :return_type: str or dict
+    """
+
+    if not sender_keypair.identity:
+        raise exceptions.IdentityRequired
+
+    if not isinstance(recipient_keypairs, collections.Iterable):
+        recipient_keypairs = [recipient_keypairs]
+
+    claims = jose.normalize_claims(raw_claims)
+    plaintext = json_encoder(claims)
+    nonce = claims['jti']
+
+    ephemeral_keypair = service.create_secret_key()
+    common_header = _make_header(claims, sender_keypair.identity, ephemeral_keypair)
+    cek = service.create_aes_key()
+    encrypted_claims = service.encrypt_attr_value(plaintext, cek, legacy_support=False)
+
+    ret = {
+        "unprotected": common_header,
+        "iv": utils.to_string(encrypted_claims['iv']),
+        "ciphertext": utils.to_string(encrypted_claims['ciphertext']),
+        "tag": utils.to_string(encrypted_claims['tag']),
+        "recipients": [
+            _encrypt_to_recipient(cek, sender_keypair.identity, ephemeral_keypair, keypair, nonce)
+            for keypair in recipient_keypairs
+        ],
+    }
+
+    del cek, ephemeral_keypair  # this wont wipe the memory, but is the best we can do in Python
+
+    if jsonify:
+        ret = json_encoder(ret)
+
+    return ret
+
+
+def decrypt_jwe(jwe, recipient_keypair, json_decoder=json.loads):
+    """
+    Decrypt the claims in a JWE for a given recipient
+
+    :param jwe: JWE to verify and convert
+    :type jwe: str
+    :param recipient_keypair: :py:class:`~oneid.keychain.Keypair` to use to decrypt.
+    :type recipient_keypair: :py:class:`~oneid.keychain.Keypair`
+    :param json_encoder: a function to encode a :py:class:`dict` into JSON. Defaults to `json.dumps`
+    :returns: claims
+    :rtype: dict
+    :raises: :py:class:`~oneid.exceptions.InvalidFormatError`: if not a valid JWE
+    """
+
+    if not recipient_keypair.identity:
+        raise exceptions.IdentityRequired
+
+    jwe_dict = jose.as_dict(jwe, json_decoder)
+
+    if not jose.is_jwe(jwe_dict):
+        logger.debug('attempt to decrypt a non-jwe (type: %s): %s', type(jwe), jwe)
+        raise exceptions.InvalidFormatError
+
+    shared_header = jose.get_jwe_shared_header(jwe, json_decoder=json.loads)
+
+    recipient = next((
+        recipient for recipient in jwe_dict['recipients']
+        if recipient['header']['kid'] == str(recipient_keypair.identity)
+    ), None)
+
+    if not recipient:
+        logger.warning('attempt to decrypt for invalid recipient (%s)', recipient_keypair.identity)
+        raise exceptions.InvalidRecipient
+
+    jwk = shared_header.get('epk')
+    sender_keypair = keychain.Keypair.from_jwk(jwk)
+    apu = utils.base64url_decode(shared_header.get('apu'))
+    apv = utils.base64url_decode(recipient['header']['apv'])
+
+    kek = recipient_keypair.ecdh(sender_keypair, party_u_info=apu, party_v_info=apv)
+    e_cek = utils.base64url_decode(recipient['encrypted_key'])
+
+    try:
+        cek = service.key_unwrap(kek, e_cek)
+    except:
+        logger.warning('invalid attempt to decrypt CEK, id=%s', recipient_keypair.identity)
+        raise exceptions.DecryptionFailed
+
+    # recast into form expected by decrypt_attr_value
+    # TODO: have it be more flexible?
+    #
+    attr_value = {
+        key: base64.b64encode(utils.base64url_decode(value))
+        for key, value in jwe_dict.items()
+        if key in ['iv', 'ciphertext', 'tag']
+    }
+    # 'cipher': 'aes', mode': 'gcm' are assumed, 'ts': 128 isn't needed
+
+    try:
+        claims = service.decrypt_attr_value(attr_value, cek)
+    except:
+        logger.warning('invalid attempt to decrypt claims, id=%s', recipient_keypair.identity)
+        raise exceptions.DecryptionFailed
+
+    return json_decoder(utils.to_string(claims))
+
+
+def _make_header(claims, sender_identity, ephemeral_keypair):
+    HEADER_EXTRACTED_CLAIMS = ['iss', 'jti', 'nbf', 'exp', 'aud']
+
+    common = {k: v for k, v in claims.items() if k in HEADER_EXTRACTED_CLAIMS}
+    nonce = claims['jti']
+    epk = ephemeral_keypair.jwk_public
+
+    if any([k in claims for k in NON_OVERRIDABLE_CLAIMS]):
+        raise ValueError
+
+    common.update({
+        "enc": "A256GCM",
+        "alg": "ECDH-ES+A256KW",
+        "epk": epk,
+        "apu": utils.to_string(utils.base64url_encode(str(sender_identity) + nonce)),
+    })
+    return common
+
+
+def _encrypt_to_recipient(cek, sender_identity, ephemeral_keypair, recipient_keypair, nonce):
+    apu = utils.to_bytes(str(sender_identity) + nonce)
+    apv = utils.to_bytes(str(recipient_keypair.identity) + nonce)
+
+    ret = {
+      "header": {
+        "kid": recipient_keypair.identity,
+        "apv": utils.to_string(utils.base64url_encode(apv)),
+      },
+    }
+    kek = ephemeral_keypair.ecdh(recipient_keypair, party_u_info=apu, party_v_info=apv)
+    encrypted_key = service.key_wrap(kek, cek)
+    ret['encrypted_key'] = utils.to_string(utils.base64url_encode(encrypted_key))
+
+    del kek
+
+    return ret

--- a/src/oneid/jwts.py
+++ b/src/oneid/jwts.py
@@ -14,20 +14,16 @@ from __future__ import unicode_literals
 import six
 import collections
 import json
-import re
 import time
 import logging
 
 from datetime import datetime
-from dateutil import parser, tz
+from dateutil import tz
 
-from . import nonces, utils, exceptions
+from . import jose, nonces, utils, exceptions
 
 logger = logging.getLogger(__name__)
 
-
-B64_URLSAFE_RE = '[0-9a-zA-Z-_]+'
-COMPACT_JWS_RE = r'^{b64}\.{b64}\.{b64}$'.format(b64=B64_URLSAFE_RE)
 
 RESERVED_HEADERS = [
     'typ',
@@ -48,10 +44,6 @@ TOKEN_NOT_BEFORE_LEEWAY_SEC = (2 * 60)   # two minutes
 TOKEN_EXPIRATION_LEEWAY_SEC = (3)      # three seconds
 
 
-def is_compact(jws):
-    return bool(re.match(COMPACT_JWS_RE, jws))
-
-
 def make_jwt(raw_claims, keypair, json_encoder=json.dumps):
     """
     Convert claims into JWT
@@ -66,7 +58,7 @@ def make_jwt(raw_claims, keypair, json_encoder=json.dumps):
         raise TypeError('dict required for claims, type=' +
                         str(type(raw_claims)))
 
-    claims = _normalize_claims(raw_claims, keypair.identity)
+    claims = jose.normalize_claims(raw_claims, keypair.identity)
     claims_serialized = json_encoder(claims)
     claims_b64 = utils.to_string(utils.base64url_encode(claims_serialized))
 
@@ -102,7 +94,7 @@ def verify_jwt(jwt, keypair=None, json_decoder=json.loads):
     """
     jwt = utils.to_string(jwt)
 
-    if not is_compact(jwt):
+    if not jose.is_compact_jws(jwt):
         logger.debug('Given JWT doesnt match pattern: %s', jwt)
         raise exceptions.InvalidFormatError
 
@@ -155,7 +147,7 @@ def make_jws(raw_claims, ordered_keypairs, multiple_sig_headers=None, json_encod
     multiple_sig_headers = _validated_headers(ordered_keypairs, multiple_sig_headers)
     multiple_sig_headers = _add_signature_indexes(multiple_sig_headers)
 
-    claims = _normalize_claims(raw_claims)
+    claims = jose.normalize_claims(raw_claims)
     claims_serialized = json_encoder(claims)
     claims_b64 = utils.to_string(utils.base64url_encode(claims_serialized))
 
@@ -264,7 +256,7 @@ def get_jws_key_ids(jws, default_kid=None, json_decoder=json.loads, ordered=Fals
 
     jws = utils.to_string(jws)
 
-    if is_compact(jws):
+    if jose.is_compact_jws(jws):
         header_b64, claims_b64, _ = jws.split('.')
         header = json_decoder(utils.to_string(
             utils.base64url_decode(header_b64)))
@@ -333,7 +325,7 @@ def verify_jws(jws, keypairs=None, verify_all=True, default_kid=None, json_decod
 
     jws = utils.to_string(jws)
 
-    if is_compact(jws):
+    if jose.is_compact_jws(jws):
 
         if verify_all and keypairs and len(keypairs) != 1:
             raise exceptions.InvalidSignatureError(
@@ -381,7 +373,7 @@ def get_jws_headers(jws, json_decoder=json.loads):
 
 # def _extract_claim(jws, claim):
 #
-#     if is_compact(jws):
+#     if jose.is_compact_jws(jws):
 #         claims_b64 = jws.split('.')[1]
 #     else:
 #         jws_dict = json.loads(jws)
@@ -439,48 +431,11 @@ def _add_signature_indexes(multiple_sig_headers, offset=0):
             for idx, headers in enumerate(multiple_sig_headers)]
 
 
-def _normalize_claims(raw_claims, issuer=None):
-    exp = None
-    nonce = None
-
-    if 'exp' in raw_claims and 'jti' not in raw_claims:
-        # use message expiration for nonce expiration
-        exp = raw_claims.get('exp')
-        exp_dt = datetime.fromtimestamp(exp, tz.tzutc())
-        nonce = nonces.make_nonce(exp_dt)
-    elif 'jti' in raw_claims and (raw_claims['jti'][:3] == '002') and 'exp' not in raw_claims:
-        # use >v1 nonce expiration for message expiration
-        try:
-            nonce = raw_claims.get('jti')
-            nonce_dt = parser.parse(nonce[3:-6])
-            exp = (nonce_dt - datetime(1970, 1, 1,
-                                       tzinfo=tz.tzutc())).total_seconds()
-        except:
-            logger.warning(
-                'unable to parse jti for nonce exp, using default, jti=%s', nonce)
-
-    now = int(time.time())
-    default_exp_ts = (now + TOKEN_EXPIRATION_TIME_SEC)
-    default_exp_dt = datetime.fromtimestamp(default_exp_ts, tz.tzutc())
-
-    claims = {
-        'jti': nonce or nonces.make_nonce(default_exp_dt),
-        'nbf': now,
-        'exp': exp or default_exp_ts,
-    }
-    if issuer:
-        claims['iss'] = issuer
-
-    claims.update(raw_claims)
-
-    return claims
-
-
 def _jws_as_dict(jws, kid, json_decoder):
 
     jws = utils.to_string(jws)
 
-    if not is_compact(jws):
+    if not jose.is_compact_jws(jws):
         return json_decoder(jws)
 
     header_b64, payload, signature = jws.split('.')

--- a/src/oneid/keychain.py
+++ b/src/oneid/keychain.py
@@ -31,6 +31,8 @@ KEYSIZE_BYTES = (KEYSIZE // 8)
 
 logger = logging.getLogger(__name__)
 
+_BACKEND = default_backend()
+
 
 class Credentials(object):
     """
@@ -77,7 +79,7 @@ class ProjectCredentials(Credentials):
         cipher_alg = Cipher(
             algorithms.AES(self._encryption_key),
             modes.GCM(iv),
-            backend=default_backend()
+            backend=_BACKEND
         )
         encryptor = cipher_alg.encryptor()
         encr_value = encryptor.update(utils.to_bytes(plain_text)) + encryptor.finalize()
@@ -121,7 +123,7 @@ class ProjectCredentials(Credentials):
         ct = tag_ct[:-ts]
         cipher_alg = Cipher(algorithms.AES(self._encryption_key),
                             modes.GCM(iv, tag, min_tag_length=8),
-                            backend=default_backend())
+                            backend=_BACKEND)
         decryptor = cipher_alg.decryptor()
         return decryptor.update(ct) + decryptor.finalize()
 
@@ -217,12 +219,12 @@ class Keypair(BaseKeypair):
         :return: :class:`~oneid.keychain.Keypair` instance
         """
         if key_bytes:
-            secret_bytes = load_pem_private_key(utils.to_bytes(key_bytes), None, default_backend())
+            secret_bytes = load_pem_private_key(utils.to_bytes(key_bytes), None, _BACKEND)
             return cls(secret_bytes=secret_bytes)
 
         if file_adapter.file_exists(path):
             with file_adapter.read_file(path) as pem_data:
-                secret_bytes = load_pem_private_key(pem_data, None, default_backend())
+                secret_bytes = load_pem_private_key(pem_data, None, _BACKEND)
                 return cls(secret_bytes=secret_bytes)
 
     @classmethod
@@ -245,7 +247,7 @@ class Keypair(BaseKeypair):
 
         if public_bytes:
             ret = cls()
-            ret._public_key = load_pem_public_key(public_bytes, default_backend())
+            ret._public_key = load_pem_public_key(public_bytes, _BACKEND)
 
         return ret
 
@@ -257,7 +259,7 @@ class Keypair(BaseKeypair):
         :param path: der formatted key
         :return:
         """
-        secret_bytes = load_der_private_key(der_key, None, default_backend())
+        secret_bytes = load_der_private_key(der_key, None, _BACKEND)
         return cls(secret_bytes=secret_bytes)
 
     @classmethod
@@ -269,7 +271,7 @@ class Keypair(BaseKeypair):
         :param public_key: der formatted key
         :return: :class:`~oneid.keychain.Keypair` instance
         """
-        pub = load_der_public_key(public_key, default_backend())
+        pub = load_der_public_key(public_key, _BACKEND)
 
         new_token = cls()
         new_token._public_key = pub

--- a/src/oneid/keychain.py
+++ b/src/oneid/keychain.py
@@ -253,6 +253,7 @@ class Keypair(BaseKeypair):
     def from_secret_der(cls, der_key):
         """
         Read a der_key, convert it a private key
+
         :param path: der formatted key
         :return:
         """
@@ -264,6 +265,7 @@ class Keypair(BaseKeypair):
         """
         Given a DER-format public key, convert it into a token to
         validate signatures
+
         :param public_key: der formatted key
         :return: :class:`~oneid.keychain.Keypair` instance
         """
@@ -277,12 +279,12 @@ class Keypair(BaseKeypair):
     def verify(self, payload, signature):
         """
         Verify that the token signed the data
+
         :type payload: String
         :param payload: message that was signed and needs verified
         :type signature: Base64 URL Safe
         :param signature: Signature that can verify the sender\'s identity and payload
         :return:
-
         """
         raw_sig = utils.base64url_decode(signature)
         sig_r_bin = raw_sig[:len(raw_sig)//2]
@@ -299,6 +301,7 @@ class Keypair(BaseKeypair):
     def sign(self, payload):
         """
         Sign a payload
+
         :param payload: String (usually jwt payload)
         :return: URL safe base64 signature
         """
@@ -319,6 +322,7 @@ class Keypair(BaseKeypair):
     def public_key(self):
         """
         If the private key is defined, generate the public key
+
         :return:
         """
         if self._public_key:

--- a/src/oneid/nonces.py
+++ b/src/oneid/nonces.py
@@ -79,6 +79,7 @@ def _default_nonce_verifier(nonce):
             )
     return True
 
+
 _nonce_verifier = _default_nonce_verifier
 
 
@@ -93,6 +94,7 @@ def _default_nonce_burner(nonce):
         fd.write(nonce + '\n')
 
     return True
+
 
 _nonce_burner = _default_nonce_burner
 

--- a/src/oneid/service.py
+++ b/src/oneid/service.py
@@ -16,6 +16,7 @@ from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.serialization \
     import Encoding, PrivateFormat, NoEncryption
+from cryptography.hazmat.primitives.keywrap import aes_key_wrap, aes_key_unwrap
 
 from .keychain import Keypair
 from . import jwts
@@ -282,3 +283,11 @@ def decrypt_attr_value(attr_ct, aes_key):
     )
     decryptor = cipher_alg.decryptor()
     return decryptor.update(ciphertext) + decryptor.finalize()
+
+
+def key_wrap(wrapping_key, key_to_wrap):
+    return aes_key_wrap(wrapping_key, key_to_wrap, _BACKEND)
+
+
+def key_unwrap(wrapping_key, wrapped_key):
+    return aes_key_unwrap(wrapping_key, wrapped_key, _BACKEND)

--- a/src/oneid/service.py
+++ b/src/oneid/service.py
@@ -27,6 +27,8 @@ logger = logging.getLogger(__name__)
 
 AUTHENTICATION_ENDPOINT = 'http://developer-portal.oneid.com/api/{project}/authenticate'
 
+_BACKEND = default_backend()
+
 
 class ServiceCreator(object):
     """
@@ -181,7 +183,7 @@ def create_secret_key(output=None):
     :param output: Path to save the secret key
     :return: oneid.keychain.Keypair
     """
-    secret_key = ec.generate_private_key(ec.SECP256R1(), default_backend())
+    secret_key = ec.generate_private_key(ec.SECP256R1(), _BACKEND)
     secret_key_bytes = secret_key.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption())
 
     # Save the secret key bytes to a secure file
@@ -209,7 +211,7 @@ def encrypt_attr_value(attr_value, aes_key):
     :return: Dictionary with base64 encoded cipher text and base 64 encoded iv
     """
     iv = os.urandom(16)
-    cipher_alg = Cipher(algorithms.AES(aes_key), modes.GCM(iv), backend=default_backend())
+    cipher_alg = Cipher(algorithms.AES(aes_key), modes.GCM(iv), backend=_BACKEND)
     encryptor = cipher_alg.encryptor()
     encr_value = encryptor.update(utils.to_bytes(attr_value)) + encryptor.finalize()
     encr_value_b64 = base64.b64encode(encr_value + encryptor.tag)
@@ -239,7 +241,7 @@ def decrypt_attr_value(attr_ct, aes_key):
     cipher_alg = Cipher(
         algorithms.AES(aes_key),
         modes.GCM(iv, tag, min_tag_length=8),
-        backend=default_backend()
+        backend=_BACKEND
     )
     decryptor = cipher_alg.decryptor()
     return decryptor.update(ct) + decryptor.finalize()

--- a/src/oneid/service.py
+++ b/src/oneid/service.py
@@ -202,46 +202,83 @@ def create_aes_key():
     return os.urandom(32)
 
 
-def encrypt_attr_value(attr_value, aes_key):
+def encrypt_attr_value(attr_value, aes_key, legacy_support=True):
     """
     Convenience method to encrypt attribute properties
 
     :param attr_value: plain text (string or bytes) that you want encrypted
     :param aes_key: symmetric key to encrypt attribute value with
-    :return: Dictionary with base64 encoded cipher text and base 64 encoded iv
+    :return: Dictionary (Flattened JWE) with base64-encoded ciphertext and base64-encoded iv
     """
     iv = os.urandom(16)
     cipher_alg = Cipher(algorithms.AES(aes_key), modes.GCM(iv), backend=_BACKEND)
     encryptor = cipher_alg.encryptor()
     encr_value = encryptor.update(utils.to_bytes(attr_value)) + encryptor.finalize()
-    encr_value_b64 = base64.b64encode(encr_value + encryptor.tag)
-    iv_b64 = base64.b64encode(iv)
-    return {'cipher': 'aes', 'mode': 'gcm', 'ts': 128, 'iv': iv_b64, 'ct': encr_value_b64}
+    ciphertext_b64 = utils.base64url_encode(encr_value)
+    tag_b64 = utils.base64url_encode(encryptor.tag)
+    iv_b64 = base64.b64encode(iv) if legacy_support else utils.base64url_encode(iv)
+    ret = {
+      "header": {
+        "alg": "dir",
+        "enc": "A256GCM"
+      },
+      "iv": iv_b64,
+      "ciphertext": ciphertext_b64,
+      "tag": tag_b64,
+    }
+
+    if legacy_support:
+        ct_b64 = base64.b64encode(encr_value + encryptor.tag)
+        ret.update({
+          "cipher": "aes",
+          "mode": "gcm",
+          "ts": 128,
+          "ct": ct_b64,
+        })
+    return ret
 
 
 def decrypt_attr_value(attr_ct, aes_key):
     """
     Convenience method to decrypt attribute properties
 
-    :param attr_ct: Dictionary with base64 encoded cipher text and base 64 encoded iv
+    :param attr_ct: Dictionary (may be a Flattened JWE) with base64-encoded
+        ciphertext and base64-encoded iv
     :param aes_key: symmetric key to decrypt attribute value with
     :return: plaintext bytes
     """
-    if not isinstance(attr_ct, dict) or \
-            attr_ct.get('cipher', 'aes') != 'aes' or \
-            attr_ct.get('mode', 'gcm') != 'gcm':
-
+    if not isinstance(attr_ct, dict) or (
+        attr_ct.get('cipher', 'aes') != 'aes' or
+        attr_ct.get('mode', 'gcm') != 'gcm' or
+        (
+            'header' in attr_ct and (
+                attr_ct['header'].get('alg', 'dir') != 'dir' or
+                attr_ct['header'].get('env', 'A256GCM') != 'A256GCM'
+            )
+        )
+    ):
         raise ValueError('invalid encrypted attribute')
 
-    iv = base64.b64decode(attr_ct['iv'])
-    tag_ct = base64.b64decode(attr_ct['ct'])
-    ts = attr_ct.get('ts', 64) // 8
-    tag = tag_ct[-ts:]
-    ct = tag_ct[:-ts]
+    iv = None
+    ciphertext = None
+
+    if 'ciphertext' in attr_ct:
+        # JWE included, prefer that
+        ciphertext = utils.base64url_decode(attr_ct.get('ciphertext'))
+        tag = utils.base64url_decode(attr_ct.get('tag'))
+        iv = utils.base64url_decode(attr_ct['iv'])
+    else:
+        # legacy only
+        iv = base64.b64decode(attr_ct['iv'])
+        tag_ct = base64.b64decode(attr_ct['ct'])
+        ts = attr_ct.get('ts', 64) // 8
+        ciphertext = tag_ct[:-ts]
+        tag = tag_ct[-ts:]
+
     cipher_alg = Cipher(
         algorithms.AES(aes_key),
         modes.GCM(iv, tag, min_tag_length=8),
         backend=_BACKEND
     )
     decryptor = cipher_alg.decryptor()
-    return decryptor.update(ct) + decryptor.finalize()
+    return decryptor.update(ciphertext) + decryptor.finalize()

--- a/src/oneid/session.py
+++ b/src/oneid/session.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
 import os
-import json
 import yaml
 import collections
 import logging
@@ -125,7 +124,7 @@ class DeviceSession(SessionBase):
 
     def verify_message(self, message, rekey_credentials=None):
         """
-        Verify a message received from the server
+        Verify a message received from the Project
 
         :param message: JSON formatted JWS with at least two signatures
         :param rekey_credentials: List of :class:`~oneid.keychain.Credential`
@@ -209,12 +208,12 @@ class ServerSession(SessionBase):
         if rekey_credentials:
             keypairs += [credentials.keypair for credentials in rekey_credentials]
 
-        message = kwargs.get('raw_message', json.dumps(kwargs))
+        jws = jwts.make_jws(kwargs, self.identity_credentials.keypair)
 
         oneid_response = self.authenticate.server(
             project_id=self.project_credentials.keypair.identity,
             identity=self.identity_credentials.keypair.identity,
-            message=message
+            body=jws
         )
 
         if not oneid_response:

--- a/src/oneid/session.py
+++ b/src/oneid/session.py
@@ -235,7 +235,7 @@ class ServerSession(SessionBase):
 
         :param message: JSON formatted JWS or JWT signed by the Device
         :param device_credentials: :class:`~oneid.keychain.Credential` (or list of them)
-        to verify Device signature(s) against
+            to verify Device signature(s) against
         :param get_oneid_cosignature: (default: True) verify with oneID first
         :return: verified message or False if not valid
         """

--- a/src/oneid/session.py
+++ b/src/oneid/session.py
@@ -8,7 +8,7 @@ import logging
 from requests import request
 from codecs import open
 
-from . import service, jwts, exceptions
+from . import service, jose, jwts, jwes, exceptions
 
 logger = logging.getLogger(__name__)
 
@@ -20,20 +20,27 @@ class SessionBase(object):
     :ivar identity_credentials: oneID identity :class:`~oneid.keychain.Credentials`
     :ivar project_credentials: unique project credentials :class:`~oneid.keychain.Credentials`
     :ivar oneid_credentials: oneID project credentials :class:`~oneid.keychain.Credentials`
+    :ivar oneid_credentials: peer credentials :class:`~oneid.keychain.Credentials`
+    :ivar config: Dictionary or configuration keyword arguments
     """
     def __init__(self, identity_credentials=None, project_credentials=None,
-                 oneid_credentials=None, config=None):
+                 oneid_credentials=None, peer_credentials=None, config=None):
         """
 
         :param identity_credentials: :py:class:`~oneid.keychain.Credentials`
         :param project_credentials: :py:class:`~oneid.keychain.ProjectCredentials`
         :param oneid_credentials: :py:class:`~oneid.keychain.Credentials`
+        :param peer_credentials: list of :py:class:`~oneid.keychain.Credentials`
+            If provided, session will be encrypted to recipients
         :param config: Dictionary or configuration keyword arguments
         :return:
         """
         self.identity_credentials = identity_credentials
         self.project_credentials = project_credentials
         self.oneid_credentials = oneid_credentials
+        self.peer_credentials = peer_credentials
+        if peer_credentials and not isinstance(peer_credentials, collections.Iterable):
+            self.peer_credentials = [peer_credentials]
 
     def _load_config(self, config_file):
         """
@@ -61,6 +68,17 @@ class SessionBase(object):
                                                              self,
                                                              **kwargs)
                         )
+
+    def _get_recipient_keypairs(self, encrypt_to_peers, other_recipients):
+        recipients = []
+
+        if encrypt_to_peers and self.peer_credentials:
+            recipients += self.peer_credentials
+
+        if other_recipients:
+            recipients += other_recipients
+
+        return [c.keypair for c in recipients]
 
     def make_http_request(self, http_method, url, headers=None, body=None):
         """
@@ -117,10 +135,11 @@ class SessionBase(object):
 
 class DeviceSession(SessionBase):
     def __init__(self, identity_credentials=None, project_credentials=None,
-                 oneid_credentials=None, config=None):
+                 oneid_credentials=None, peer_credentials=None, config=None):
         super(DeviceSession, self).__init__(identity_credentials,
                                             project_credentials,
-                                            oneid_credentials, config)
+                                            oneid_credentials,
+                                            peer_credentials, config)
 
     def verify_message(self, message, rekey_credentials=None):
         """
@@ -143,17 +162,35 @@ class DeviceSession(SessionBase):
         else:
             keypairs = standard_keypairs
 
-        return jwts.verify_jws(message, keypairs)
+        ret = jwts.verify_jws(message, keypairs)
 
-    def prepare_message(self, *args, **kwargs):
+        if jose.is_jwe(ret):
+            ret = jwes.decrypt_jwe(ret, self.identity_credentials.keypair)
+
+        return ret
+
+    def prepare_message(self, encrypt_to_peers=True, other_recipients=None, *args, **kwargs):
         """
         Prepare a message before sending
 
-        :return: Signed JWT
+        :param encrypt_to_peers: If True (default), and peer_credentials available,
+            encrypt the message to them
+        :type encrypt_to_peers: bool
+        :param other_recipients: Additional recipients to encrypt to
+        :type other_recipients: list of :class:`~oneid.keychain.Credential`
+        :return: Signed JWS
         """
-        kwargs['iss'] = self.identity_credentials.id
+        claims = kwargs
+        claims['iss'] = self.identity_credentials.id
 
-        return jwts.make_jwt(kwargs, self.identity_credentials.keypair)
+        recipient_keypairs = self._get_recipient_keypairs(encrypt_to_peers, other_recipients)
+
+        if recipient_keypairs:
+            claims = jwes.make_jwe(
+                claims, self.identity_credentials.keypair, recipient_keypairs, jsonify=False
+            )
+
+        return jwts.make_jws(claims, self.identity_credentials.keypair)
 
     def send_message(self, *args, **kwargs):
         raise NotImplementedError
@@ -164,10 +201,11 @@ class ServerSession(SessionBase):
     Enable Server to request two-factor Authentication from oneID
     """
     def __init__(self, identity_credentials=None, project_credentials=None,
-                 oneid_credentials=None, config=None):
+                 oneid_credentials=None, peer_credentials=None, config=None):
         super(ServerSession, self).__init__(identity_credentials,
                                             project_credentials,
-                                            oneid_credentials, config)
+                                            oneid_credentials,
+                                            peer_credentials, config)
 
         if isinstance(config, dict):
             params = config
@@ -190,13 +228,19 @@ class ServerSession(SessionBase):
 
         super(ServerSession, self)._create_services(params, **global_kwargs)
 
-    def prepare_message(self, rekey_credentials=None, **kwargs):
+    def prepare_message(self, rekey_credentials=None, encrypt_to_peers=True,
+                        other_recipients=None, **kwargs):
         """
         Build message that has two-factor signatures
 
         :param rekey_credentials: (optional) rekey credentials
         :type rekey_credentials: list
-        :return: Content to be sent to devices
+        :param encrypt_to_peers: If True (default), and peer_credentials available,
+            encrypt the message to them
+        :type encrypt_to_peers: bool
+        :param other_recipients: Additional recipients to encrypt to
+        :type other_recipients: list of :class:`~oneid.keychain.Credential`
+        :return: Signed JWS to be sent to devices
         """
         if self.project_credentials is None:
             raise AttributeError
@@ -208,7 +252,17 @@ class ServerSession(SessionBase):
         if rekey_credentials:
             keypairs += [credentials.keypair for credentials in rekey_credentials]
 
-        jws = jwts.make_jws(kwargs, self.identity_credentials.keypair)
+        claims = kwargs
+        claims['iss'] = self.identity_credentials.id
+
+        recipient_keypairs = self._get_recipient_keypairs(encrypt_to_peers, other_recipients)
+
+        if recipient_keypairs:
+            claims = jwes.make_jwe(
+                claims, self.identity_credentials.keypair, recipient_keypairs, jsonify=False
+            )
+
+        jws = jwts.make_jws(claims, self.identity_credentials.keypair)
 
         oneid_response = self.authenticate.server(
             project_id=self.project_credentials.keypair.identity,
@@ -261,7 +315,12 @@ class ServerSession(SessionBase):
                 logger.debug('oneID refused to co-sign device message')
                 raise exceptions.InvalidAuthentication
 
-        return jwts.verify_jws(message, keypairs)
+        ret = jwts.verify_jws(message, keypairs)
+
+        if jose.is_jwe(ret):
+            ret = jwes.decrypt_jwe(ret, self.identity_credentials.keypair)
+
+        return ret
 
 
 class AdminSession(SessionBase):

--- a/src/oneid/utils.py
+++ b/src/oneid/utils.py
@@ -7,7 +7,13 @@ import six
 import base64
 import logging
 
+from datetime import datetime
+from dateutil import parser, tz
+
 logger = logging.getLogger(__name__)
+
+UTC = tz.tzutc()
+EPOCH = datetime(1970, 1, 1, tzinfo=UTC)
 
 
 def to_bytes(data):
@@ -16,6 +22,16 @@ def to_bytes(data):
 
 def to_string(data):
     return data if isinstance(data, six.text_type) else data.decode('utf-8')
+
+
+def to_timestamp(dt):
+    if not isinstance(dt, datetime):
+        dt = parser.parse(dt)
+    return (dt - EPOCH).total_seconds()
+
+
+def from_timestamp(timestamp):
+    return datetime.fromtimestamp(timestamp, UTC)
 
 
 def base64url_encode(msg):

--- a/tests/test_jose.py
+++ b/tests/test_jose.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import os
+import json
+import tempfile
+import uuid
+
+import logging
+
+from unittest import TestCase
+
+# from nose.tools import nottest
+
+from oneid import jose, jwts, service, nonces, utils
+
+logger = logging.getLogger(__name__)
+
+
+class TestIsJWS(TestCase):
+    def setUp(self):
+        # self.tmpdir = tempfile.mkdtemp()
+        # os.environ['HOME'] = self.tmpdir
+        # nonces.set_nonce_handlers(lambda _n: True, lambda _n: True)
+
+        self.claim_keys = ['a', 'b', 'c', 'héllo!', '😬']
+        self.raw_claims = {k: 0 for k in self.claim_keys}
+
+        self.keypair = service.create_secret_key()
+        self.keypair.identity = str(uuid.uuid4())
+
+        self.jws = jwts.make_jws(self.raw_claims, self.keypair)
+        self.jwt = jwts.make_jwt(self.raw_claims, self.keypair)
+
+    def tearDown(self):
+        # nonces.set_nonce_handlers(nonces._default_nonce_verifier, nonces._default_nonce_burner)
+        pass
+
+    def test_with_jws(self):
+        self.assertTrue(jose.is_jws(self.jws))
+        self.assertTrue(jose.is_jws(json.loads(self.jws)))
+        self.assertFalse(jose.is_jws([]))
+        self.assertFalse(jose.is_jws("[]"))
+
+        for k in ['payload', 'signatures']:
+            jws_json = json.loads(self.jws)
+            del jws_json[k]
+            self.assertFalse(jose.is_jws(json.dumps(jws_json)))
+
+    def test_with_jwt(self):
+        self.assertTrue(jose.is_jws(self.jwt))
+
+
+class TestNormalizeClaims(TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        os.environ['HOME'] = self.tmpdir
+        nonces.set_nonce_handlers(lambda _n: True, lambda _n: True)
+
+        self.claim_keys = ['a', 'b', 'c', 'héllo!', '😬']
+        self.raw_claims = {k: 0 for k in self.claim_keys}
+
+        self.standard_claims = {
+            'iss': str(uuid.uuid4()),
+            'jti': nonces.make_nonce(),
+            'nbf': 12345,
+            'exp': 12346,
+        }
+
+    def tearDown(self):
+        nonces.set_nonce_handlers(nonces._default_nonce_verifier, nonces._default_nonce_burner)
+
+    def test_sunny_day(self):
+        claims = jose.normalize_claims(self.raw_claims)
+
+        self.assertIsInstance(claims, dict)
+
+        for k in self.claim_keys + ['jti', 'nbf', 'exp']:
+            self.assertIn(k, claims)
+
+        self.assertNotIn('iss', claims)
+
+        self.assertEqual(utils.to_timestamp(claims['jti'][3:-6]), claims['exp'])
+        self.assertGreater(claims['exp'], claims['nbf'])
+
+    def test_sunny_day_with_issuer(self):
+        iss = 'me'
+        claims = jose.normalize_claims(self.raw_claims, iss)
+
+        self.assertIn('iss', claims)
+        self.assertEqual(claims['iss'], iss)
+
+    def test_existing_standard_claims(self):
+        self.raw_claims.update(self.standard_claims)
+        claims = jose.normalize_claims(self.raw_claims)
+
+        for claim, value in self.standard_claims.items():
+            self.assertIn(claim, claims)
+            self.assertEqual(claims[claim], value)
+
+    def test_using_existing_expiration_in_nonce(self):
+        datestr = '2016-12-03T15:12:15Z'
+        exp = utils.to_timestamp(datestr)
+
+        self.raw_claims.update({'exp': exp})
+        claims = jose.normalize_claims(self.raw_claims)
+
+        self.assertIn('jti', claims)
+        self.assertEqual(claims['jti'][3:-6], datestr)
+
+    def test_using_nonce_expiration_in_exp(self):
+        datestr = '2016-12-03T10:12:15Z'
+        exp = utils.to_timestamp(datestr)
+        nonce = '002' + datestr + 'ABC123'
+
+        self.raw_claims.update({'jti': nonce})
+        claims = jose.normalize_claims(self.raw_claims)
+
+        self.assertIn('exp', claims)
+        self.assertEqual(claims['exp'], exp)
+
+    def test_using_v001_nonce(self):
+        datestr = '2016-12-03T10:12:15Z'
+        exp = utils.to_timestamp(datestr)
+        nonce = '001' + datestr + 'ABC123'
+
+        self.raw_claims.update({'jti': nonce})
+        claims = jose.normalize_claims(self.raw_claims)
+
+        self.assertIn('exp', claims)
+        self.assertNotEqual(claims['exp'], exp)
+
+    def test_using_invalid_nonce(self):
+        nonce = '002'
+
+        self.raw_claims.update({'jti': nonce})
+        claims = jose.normalize_claims(self.raw_claims)
+
+        self.assertIn('jti', claims)
+        self.assertEqual(claims['jti'], nonce)
+
+
+class TestAsDict(TestCase):
+
+    def test_as_dict(self):
+        obj = {
+            'a': 1,
+        }
+        obj_json = json.dumps(obj)
+
+        self.assertDictEqual(obj, jose.as_dict(obj_json))
+        self.assertDictEqual(obj, jose.as_dict(obj))

--- a/tests/test_jwes.py
+++ b/tests/test_jwes.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import os
+import json
+import uuid
+import tempfile
+
+import logging
+
+from unittest import TestCase
+
+# from nose.tools import nottest
+
+from oneid import jwes, nonces, service, exceptions, utils
+
+logger = logging.getLogger(__name__)
+
+
+def _remove_secret(keypair):
+    keypair._public_key = keypair.public_key
+    keypair._private_key = None
+
+
+def _generate_keypair(private=True):
+    ret = service.create_secret_key()
+    ret.identity = str(uuid.uuid4())
+
+    if not private:
+        _remove_secret(ret)
+
+    return ret
+
+
+class TestJWEs(TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        os.environ['HOME'] = self.tmpdir
+        nonces.set_nonce_handlers(lambda _n: True, lambda _n: True)
+
+        self.claim_keys = ['a', 'b', 'c', 'héllo!', '😬']
+        self.raw_claims = {k: 0 for k in self.claim_keys}
+
+        self.sender_keypair = service.create_secret_key()
+        self.sender_keypair.identity = str(uuid.uuid4())
+
+        self.recipient_keypairs = []
+        for _ in range(3):
+            recipient_keypair = _generate_keypair()
+            self.recipient_keypairs.append(recipient_keypair)
+        self.jwe = jwes.make_jwe(self.raw_claims, self.sender_keypair, self.recipient_keypairs)
+
+    def tearDown(self):
+        nonces.set_nonce_handlers(nonces._default_nonce_verifier, nonces._default_nonce_burner)
+
+    def _assertValidClaims(self, claims, expected_claim_keys=None):
+        if expected_claim_keys is None:
+            expected_claim_keys = self.claim_keys
+
+        for k in expected_claim_keys + ['jti', 'nbf', 'exp']:
+            self.assertIn(k, claims)
+
+    def test_sunny_day(self):
+        logger.debug('jwe=%s', self.jwe)
+        jwe_json = json.loads(self.jwe)
+        self.assertNotIn('d', jwe_json['unprotected']['epk'])
+
+        for recipient_keypair in self.recipient_keypairs:
+            claims = jwes.decrypt_jwe(self.jwe, recipient_keypair)
+            self._assertValidClaims(claims)
+
+    def test_skip_jsonify(self):
+        self.assertIsInstance(self.jwe, str)
+
+        claims1 = jwes.decrypt_jwe(self.jwe, self.recipient_keypairs[0])
+
+        jwe_json = jwes.make_jwe(
+            claims1, self.sender_keypair, self.recipient_keypairs, jsonify=False
+        )
+        self.assertIsInstance(jwe_json, dict)
+
+        claims2 = jwes.decrypt_jwe(jwe_json, self.recipient_keypairs[0])
+
+        self.assertDictEqual(claims1, claims2)
+
+    def test_key_not_present(self):
+        eve_keypair = _generate_keypair(False)
+        with self.assertRaises(exceptions.InvalidRecipient):
+            jwes.decrypt_jwe(self.jwe, eve_keypair)
+
+    def test_protected_header_overrides(self):
+        jwe_json = json.loads(self.jwe)
+        jwe_json['protected'] = utils.to_string(utils.base64url_encode(json.dumps({
+            "apu": utils.to_string(utils.base64url_encode('bogus')),
+        })))
+        jwe = json.dumps(jwe_json)
+
+        with self.assertRaises(exceptions.DecryptionFailed):
+            jwes.decrypt_jwe(jwe, self.recipient_keypairs[0])
+
+    def test_single_recipient(self):
+        jwe = jwes.make_jwe(self.raw_claims, self.sender_keypair, self.recipient_keypairs[0])
+
+        claims = jwes.decrypt_jwe(jwe, self.recipient_keypairs[0])
+        self._assertValidClaims(claims)
+
+        with self.assertRaises(exceptions.InvalidRecipient):
+            jwes.decrypt_jwe(jwe, self.recipient_keypairs[1])
+
+    def test_anonymous_sender(self):
+        with self.assertRaises(exceptions.IdentityRequired):
+            sender_keypair = service.create_secret_key()
+            jwes.make_jwe(self.raw_claims, sender_keypair, self.recipient_keypairs)
+
+    def test_anonymous_recipient(self):
+        with self.assertRaises(exceptions.IdentityRequired):
+            self.recipient_keypairs[0].identity = None
+            jwes.decrypt_jwe(self.jwe, self.recipient_keypairs[0])
+
+    def test_decrypt_invalid_jwe(self):
+        with self.assertRaises(exceptions.InvalidFormatError):
+            jwes.decrypt_jwe({}, self.recipient_keypairs[0])
+
+    def test_content_encryption_failure(self):
+        jwe_json = json.loads(self.jwe)
+        jwe_json['ciphertext'] = utils.to_string(utils.base64url_encode('bogus'))
+        jwe = json.dumps(jwe_json)
+
+        with self.assertRaises(exceptions.DecryptionFailed):
+            jwes.decrypt_jwe(jwe, self.recipient_keypairs[0])
+
+    def test_disallowed_claims(self):
+
+        for claim in ['enc', 'alg', 'epk', 'apu']:
+            with self.assertRaises(ValueError):
+                jwes.make_jwe({claim: 'bogus'}, self.sender_keypair, self.recipient_keypairs)

--- a/tests/test_keychain.py
+++ b/tests/test_keychain.py
@@ -15,6 +15,10 @@ from oneid import keychain, service, utils, exceptions
 logger = logging.getLogger(__name__)
 
 
+def _private_to_public(private_keypair):
+    return keychain.Keypair.from_public_der(private_keypair.public_key_der)
+
+
 class TestCredentials(unittest.TestCase):
     def setUp(self):
         self.uuid = uuid.uuid4()
@@ -309,3 +313,615 @@ class TestKeypair(unittest.TestCase):
         jwk['crv'] = 'P-384'
         with self.assertRaises(ValueError):
             keypair = keychain.Keypair.from_jwk(jwk)
+
+    def test_ecdh(self):
+        ue_jwk = {
+            "kty": "EC",
+            "crv": "P-256",
+            "x": "gI0GAILBdu7T53akrFmMyGcsF3n5dO7MmwNBHKW5SV0",
+            "y": "SLW_xSffzlPWrHEVI30DHM_4egVwt3NQqeUD7nMFpps",
+            "d": "0_NxaRPUMQoAJt50Gz8YiTr8gRTwyEaCumd-MToTmIo",
+        }
+        apu = 'Alice'
+        u_private_keypair = keychain.Keypair.from_jwk(ue_jwk)
+        u_public_keypair = _private_to_public(u_private_keypair)
+        v_jwk = {
+            "kty": "EC",
+            "crv": "P-256",
+            "x": "weNJy2HscCSM6AEDTDg04biOvhFhyyWvOHQfeF_PxMQ",
+            "y": "e8lnCO-AlStT-NJVX-crhB7QRYhiix03illJOVAOyck",
+            "d": "VEmDZpDXXK8p8N0Cndsxs924q6nS1RXFASRl6BfUqdw",
+        }
+        apv = 'Bob'
+        v_private_keypair = keychain.Keypair.from_jwk(v_jwk)
+        v_public_keypair = _private_to_public(v_private_keypair)
+
+        ku = u_private_keypair.ecdh(v_public_keypair, party_u_info=apu, party_v_info=apv)
+        kv = v_private_keypair.ecdh(u_public_keypair, party_u_info=apu, party_v_info=apv)
+
+        self.assertEqual(len(ku), 32)
+        self.assertEqual(ku, kv)
+
+        eve_keypair = service.create_secret_key()
+        keve = eve_keypair.ecdh(u_private_keypair, party_u_info=apu, party_v_info=apv)
+        self.assertNotEqual(ku, keve)
+
+    def test_ecdh_empty_apuv(self):
+        u_keypair = service.create_secret_key()
+        v_keypair = service.create_secret_key()
+
+        ku = u_keypair.ecdh(v_keypair)
+        kv = v_keypair.ecdh(u_keypair)
+
+        self.assertEqual(ku, kv)
+
+        eve_keypair = service.create_secret_key()
+        keve = eve_keypair.ecdh(u_keypair)
+        self.assertNotEqual(ku, keve)
+
+    def test_ecdh_public_key(self):
+        der = base64.b64decode(
+            'MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEJLzzbuz2tRnLFlOL+6bTX6giVavA'
+            'sc6NDFFT0IMCd2ibTTNUDDkFGsgq0cH5JYPg/6xUlMBFKrWYe3yQ4has9w=='
+        )
+        keypair = keychain.Keypair.from_public_der(der)
+        keypair2 = service.create_secret_key()
+
+        with self.assertRaises(exceptions.InvalidFormatError):
+            keypair.ecdh(keypair2)
+
+    def test_cavp_ecdh_vectors(self):
+        # from KASTestVectorsECC2016/Key Confirmation/ECC One Pass DH Scheme/
+        #       KASValidityTest_ECCOnePassDH_KDFConcat_KC_init_rcpt_ulat.fax
+        #   [CCM AES256] (line 20702)
+        #
+        _CAVS_VECTORS = [
+            {
+                "COUNT": "0",
+                "dsCAVS": "6d54ae0f8647c2eec0a2c2af60b56ce05d4695b9c0e7320448c6fd53cac7aa85",
+                "QsCAVSx": "237eb9a7be11382785f77252be8fc2f07e87ed5f66faceba5d0a7e11a0ce7b7d",
+                "QsCAVSy": "a11eecc27e1d93d7d08d0f26418fe36fac6ecbf569da0e2e6e66ebcd5af1aa94",
+                "deIUT": "2dc6f3853c8fc7ce8a66692539ea6c4127440e85f764cbb686fd8afc96e2478e",
+                "QeIUTx": "aab1b13842ef6dadf465700163067b2812684713c9beb678810c79d2f7d1a898",
+                "QeIUTy": "1bf139ca3a6980574abfb0e316d864cdf296fbf444924dda65d93255f31f4f6b",
+                "CCMNonce": "e46a2aa00c911408a595df62a9",
+                "OI": (
+                    "a1b2c3d4e5434156536964a98033271711305e2315ec0dab01dd636daf3f3d24"
+                    "f85855f384ffb607e15f7479d3f999"
+                ),
+                "CAVSTag": "b3b1afdd72c028ecc7e1f99065439608",
+                "Z": "730ba118d1e795e4be965263d0a9fdc53532dd0f864cd09f5b152de7ecd5f2bc",
+                "MacData": (
+                    "4b435f315f56434156536964a1b2c3d4e5aab1b13842ef6dadf465700163067b"
+                    "2812684713c9beb678810c79d2f7d1a8981bf139ca3a6980574abfb0e316d864"
+                    "cdf296fbf444924dda65d93255f31f4f6b"
+                ),
+                "DKM": "507d1de2bc5a21d73fdd4fd2ee3e22e61422e360bad13d88831764113e23b757",
+                "Result": False,
+                "errno": 1,  # CAVS's Static public key X fails PKV 5.6.2.5
+            },
+            {
+                "COUNT": "1",
+                "dsCAVS": "b7757e002d9b7afbf76fd0c59a5d24a3bfc18a8219550d2a46dfbf10bcf912d2",
+                "QsCAVSx": "19572c94032cab024f08d6230b2eb301024bdf6df9c73789b9960d63c0b7cd7f",
+                "QsCAVSy": "7b2ddb7b33cdcce010f0cb02731fe31f64febef223983fd948ad2f9bac5cd0ce",
+                "deIUT": "a235c4cba6220a937146b6c3e36ca7c867a680598cad9ad27f9814627df986cd",
+                "QeIUTx": "624a6522003c8576b3faf19a569f4de866675f5ae80cfc8762a75ab699d647a3",
+                "QeIUTy": "f5561cd92c3be54d76f2b805e2c55acec62477a31d3a1ad0c35740951107e049",
+                "CCMNonce": "1156052e04c430984aa3bdad11",
+                "OI": (
+                    "a1b2c3d4e5434156536964208bd5c82d31bfb2b025aec903a9e809be47e2df2b"
+                    "7058ecfa639c0636502f7f78bd8eaa"
+                ),
+                "CAVSTag": "1acc74dffb965458e72af945e67cbe65",
+                "Z": "042ffdeee43207064ade63862b3fa8f3a72814ce11d48df564e38747b0cb221f",
+                "MacData": (
+                    "4b435f315f56434156536964a1b2c3d4e5624a6522003c8576b3faf19a569f4d"
+                    "e866675f5ae80cfc8762a75ab699d647a3f5561cd92c3be54d76f2b805e2c55a"
+                    "cec62477a31d3a1ad0c35740951107e049"
+                ),
+                "DKM": "b06c959200ef3a2630730b604e052759df58bf7ea03d9161b8778611415fd2d3",
+                "Result": True,
+                "errno": 0,  # Correct
+            },
+            {
+                "COUNT": "2",
+                "dsCAVS": "d9267e6ab20efc7f2f677c0a72ec629ceb920d45f5650c04d377cb234c0ab528",
+                "QsCAVSx": "0daad78d2abd865245a8f29c758340fd4dd001dadb3ed93825b6d2b1505d6e44",
+                "QsCAVSy": "84f0100822f27b7d39d0b3e33a02ede7e6c3b92934b8e38692fd3e559271e504",
+                "deIUT": "49444472a299228d6903f8c04f7e0f0b6e1a9396cfced92beedf05ee4fbf08f8",
+                "QeIUTx": "7f8a540fdff29bba70429a894e3b2f484e140130b952e53afbaef790e739bddc",
+                "QeIUTy": "66f7f1c31fcf0a753e5f19a008d95cf24cf0545bb15c974fd1234e1941a9eebf",
+                "CCMNonce": "4a6497afbf32e0f2dc6fb02f63",
+                "OI": (
+                    "a1b2c3d4e5434156536964361aa22057cf81ceabf5e269d9ad3a2693ec74d3be"
+                    "16360dd3cf65b3850eeb9ba472b883"
+                ),
+                "CAVSTag": "f27efae8f581e9714cb2028844c564b7",
+                "Z": "6dd8e161a5a9d9d600d5626d4ad2dbbafa68319539f3a43fb85e5c9359f4b33f",
+                "MacData": (
+                    "4b435f315f56434156536964a1b2c3d4e57f8a540fdff29bba70429a894e3b2f"
+                    "484e140130b952e53afbaef790e739bddc66f7f1c31fcf0a753e5f19a008d95c"
+                    "f24cf0545bb15c974fd1234e1941a9eebf"
+                ),
+                "DKM": "a70cc4c10905ed83793f6a91677686e7a59a8c670f3965731c95f616489a6278",
+                "Result": True,
+                "errno": 0,  # Correct
+            },
+            {
+                "COUNT": "3",
+                "dsCAVS": "1b497ca0a1df98f6cbcda85951d70404d54853caa399a2b91dbe77005ab97700",
+                "QsCAVSx": "5b1dff9f3644f7025649d5c62f367061f27b6f46c24273349a71132025da82af",
+                "QsCAVSy": "2ac6a39d468e44c5f9178a495d9d35f20a63b7ad431bcae49e6a87921d82fe08",
+                "deIUT": "77b30d595b8d039716274bf5ac63afbe6ea58c8ddd3e4029772eaccdccffca52",
+                "QeIUTx": "b8d6cc3f4a4afd92004585fc2f664ea12bd79037ae0a3c144b977405feed6481",
+                "QeIUTy": "821ebff506587fafc3b66f583046b249aa2687021b8b133e788da3547c0a016f",
+                "CCMNonce": "21f5bb55b24bdfb765e827c1e0",
+                "OI": (
+                    "a1b2c3d4e5434156536964929c29f6e8f7474d0f3e80bbb3befaa04a66f70548"
+                    "2caa2192ac4a223612642a593b7597"
+                ),
+                "CAVSTag": "b5d59f2d64784239f7b39f0b4fa5e3a4",
+                "Z": "78a55936f6af82380cbc622f7eed314ba79bbe1ec22dcbf80bfb70d2abe593d3",
+                "MacData": (
+                    "4b435f315f56434156536964a1b2c3d4e5b8d6cc3f4a4afd92004585fc2f664e"
+                    "a12bd79037ae0a3c144b977405feed6481821ebff506587fafc3b66f583046b2"
+                    "49aa2687021b8b133e788da3547c0a016f"
+                ),
+                "DKM": "097253a7280464c6df45799a7894c8bffa0641f5691a05c2c79c729b62fd5dd2",
+                "Result": True,
+                "errno": 14,  # DKM value should have leading 0 nibble
+            },
+            {
+                "COUNT": "4",
+                "dsCAVS": "84ce55ea89cd5846a0a41c746c41a2e610153e834f04bdd517cafac186f9a5f4",
+                "QsCAVSx": "a62f7e553475ceee42c89e2288f59770d2eac6506b163328fd276cde74c5974f",
+                "QsCAVSy": "deea12e488087c716e19b0d5438782352a2045794494d48fbdf6d9bf8c68dc5b",
+                "deIUT": "fe6dd4c965ae10f48126a1dccd9b9178939ecdc7969fa3450f991a97f366093a",
+                "QeIUTx": "7284a5bde044e63a12f3c1cecd832ff748a2fe7fd2a4f784b54bb46694087479",
+                "QeIUTy": "2aa86e2bcaf738a0a0a433dd617c678b73f117ccac5637bdf10064cf39c9d481",
+                "CCMNonce": "5f78b26173502f20d1a230740e",
+                "OI": (
+                    "a1b2c3d4e543415653696465c579929daa663a91495c1fcf0503d5ec31346226"
+                    "24bbf1488b5ccbce0414824ae8a06f"
+                ),
+                "CAVSTag": "8a93deed928d04eb880bfadeb3b4909d",
+                "Z": "496a854dc33c8e0be66ac2ebdad2d2107f4b82b6c3c3ad6920583f44404cdd7b",
+                "MacData": (
+                    "4b435f315f56434156536964a1b2c3d4e57284a5bde044e63a12f3c1cecd832f"
+                    "f748a2fe7fd2a4f784b54bb466940874792aa86e2bcaf738a0a0a433dd617c67"
+                    "8b73f117ccac5637bdf10064cf39c9d481"
+                ),
+                "DKM": "c6a38211de0ebffec1c40dc05739babeae6c6c49897a565fa9898f417510e3ae",
+                "Result": True,
+                "errno": 0,  # Correct
+            },
+            # Not using COUNT=5  as we are not doing key validation
+            {
+                "COUNT": "6",
+                "dsCAVS": "eba733dc240c96875eceb2cbc7c4b775c4da98dce53780cfc9ec0f7dc9743387",
+                "QsCAVSx": "fc79ccbdd629d780a34695b1a701d931b06c41bff3001eff08a5d9c590507ed2",
+                "QsCAVSy": "c322e16d4e11004286cae551cdf57b74d853c68c1e7eceb32a1f87cd4930a3df",
+                "deIUT": "1a9925dbf033e2e774d91b432faf937285464621403da35fea7413c61fdb6d36",
+                "QeIUTx": "d164779a62408771f23d3e22be60878829c386d86bda793b7c2a4cbf86b71c36",
+                "QeIUTy": "bd2341d031fc58e43ca01cdb3795f77748c8d127bbb9f4bafa7feea8f5b0e6e5",
+                "CCMNonce": "251fe13e2c7fa1a05f1a786188",
+                "OI": (
+                    "a1b2c3d4e5434156536964427395017566581d2d5297975b35e60254e1605e24"
+                    "ff983f2553d32bd1427443d591b725"
+                ),
+                "CAVSTag": "8a34ca6d8b63257fb1c66d75aed0ebb1",
+                "Z": "8b38ba2e79aabf6427f3f8019cb35ce4b6c08dbb6c7a8adc812e76fd1e010fa8",
+                "MacData": (
+                    "4b435f315f56434156536964a1b2c3d4e5d164779a62408771f23d3e22be6087"
+                    "8829c386d86bda793b7c2a4cbf86b71c36bd2341d031fc58e43ca01cdb3795f7"
+                    "7748c8d127bbb9f4bafa7feea8f5b0e6e5"
+                ),
+                "DKM": "a4c49261de2d44c6af5817f7683f80312f1da294c5239d702d6bbb3d36242721",
+                "Result": False,
+                "errno": 2,  # CAVS's Static public key Y fails PKV 5.6.2.5
+            },
+            # Not using COUNT=7  as we are not doing key validation
+            {
+                "COUNT": "8",
+                "dsCAVS": "6bf7ff5712f2be839e72c427240f71ae69d360d25cef7948f6da961875bdf9c8",
+                "QsCAVSx": "aa5ecd446a355f9147fee31acb2315c2a07e4caf821c3483597472297e602c67",
+                "QsCAVSy": "794895148918351006031d09c50fed2a7a8231de26fb35e100dd5994df76b391",
+                "deIUT": "85bdeeec07c354faf04699ae274ffe35d2c0590dcd8368fa2a83895adbccd392",
+                "QeIUTx": "4087e5708a43f5567575a6406f975f25565529b5261aac32b53f6d282faf68e0",
+                "QeIUTy": "19145c60ced476178a4444d3258903dfe84ce3e0516653e056d510c45d8286b9",
+                "CCMNonce": "f9cb85f24b11415b7a83253789",
+                "OI": (
+                    "a1b2c3d4e54341565369645b9739bf9cacb655f1a4263bdd493f21dd7481549b"
+                    "750d4064b4ba33dc996663f0aa8a33"
+                ),
+                "CAVSTag": "d53fdf34a731418916cc84f9fac21949",
+                "Z": "0baa81f509281591a0e54b3b8c0d5d6d7852547ea0c3b854de70aa3fa9c73768",
+                "MacData": (
+                    "4b435f315f56434156536964a1b2c3d4e54087e5708a43f5567575a6406f975f"
+                    "25565529b5261aac32b53f6d282faf68e019145c60ced476178a4444d3258903"
+                    "dfe84ce3e0516653e056d510c45d8286b9"
+                ),
+                "DKM": "2a96a76a521383ac1ee26f25e8e6e6abc28c4db92cdf3b96aaf8d4f1ca49be20",
+                "Result": True,
+                "errno": 13,  # Z value should have leading 0 nibble
+            },
+            # Not sure why COUNT=9 is marked as "DKM changed", as DKM matches expected. May be
+            # a part of key validation
+            {
+                "COUNT": "10",
+                "dsCAVS": "b687cb6d92e075a26be081495fb3dbcb0c2fe361f75b96f662ca462c9a704874",
+                "QsCAVSx": "f07788f2b1dbdf5e63ef09579936bd44ede1bdc23d4760125c3193e350188fd5",
+                "QsCAVSy": "8bd38187045747859c4a72214d6e423a5d89a3143aa623b171ffd44a84d7347b",
+                "deIUT": "3c9fc1b2ffe9da2f140fa53586a873aebbf2df2071ef316ac03df87fd1cbcaa4",
+                "QeIUTx": "1d79f16d0756a4607954457f274f9e7c344ccae7bf633867ab50825d202da1ec",
+                "QeIUTy": "e60d44ec51ba05822bc9942a583b2f28c6380caca19c2f325d4431c07b9669ff",
+                "CCMNonce": "cd2023157911b18ef1496e6772",
+                "OI": (
+                    "a1b2c3d4e543415653696447b290071f5279312dbea982db0eeb637f8d6e1cd2"
+                    "60d396a4688565ce694905676b1664"
+                ),
+                "CAVSTag": "12102679d61ba4b91f6ecc94e858f10c",
+                "Z": "2d9b6457f1475d3143afc15b2e7528ed1d6b255cefee352abc15f1481dad802d",
+                "MacData": (
+                    "4b435f315f56434156536964a1b2c3d4e51d79f16d0756a4607954457f274f9e"
+                    "7c344ccae7bf633867ab50825d202da1ece60d44ec51ba05822bc9942a583b2f"
+                    "28c6380caca19c2f325d4431c07b9669ff"
+                ),
+                "DKM": "bb70d30146054017a1b0c1560fddf387b3ab3b034aaf2efc8926ff9cf55f45e1",
+                "Result": True,
+                "errno": 0,  # Correct
+            },
+            # Skippig COUNT=11 as we aren't checking Z, only DKM = KDF(Z)
+            # Not sure why COUNT=2 works, when it shouldn't, may be testing key validation
+            {
+                "COUNT": "13",
+                "dsCAVS": "3f2cf0b4440829264fe4c283528315b1791f3a303d5b6c360148011325024c46",
+                "QsCAVSx": "ab305f835862eac7ac543d51633cc637846207e4cc2ffdd94a8748b583e631d0",
+                "QsCAVSy": "aad4aadbfefa7cf349374620409512a5536f37880c1ce93f93df51a4b0fd7d1a",
+                "deIUT": "dba3921f605cf1a291950938f7bcda3eaa4e1f5cbdcd044b1cbd020f1e71e08b",
+                "QeIUTx": "7c41bd83e5bd3142d6f57181f0bc6285f546a0632e36d3806708053ca901b877",
+                "QeIUTy": "6d494921106534db2f862beda4d1a14ccc5fcf6dcaf41e17fe5431e4fa160df0",
+                "CCMNonce": "843bf88b215ce11fb1080b5e07",
+                "OI": (
+                    "a1b2c3d4e5434156536964b7e01b71c86b7c8624cc3fd2c3a6c444a68bad0a19"
+                    "273f6035bb0aa6a8ceccb6b91f9374"
+                ),
+                "CAVSTag": "71a4e3a54eee76f24cde89d5f2fdcfb4",
+                "Z": "a9ff8a7e2f7548456d1defda785033f3a317d3f1630e6ff27f321cb3613665c7",
+                "MacData": (
+                    "4b435f315f56434156536964a1b2c3d4e57c41bd83e5bd3142d6f57181f0bc62"
+                    "85f546a0632e36d3806708053ca901b8776d494921106534db2f862beda4d1a1"
+                    "4ccc5fcf6dcaf41e17fe5431e4fa160df0"
+                ),
+                "DKM": "3e79cc2ba3d9f7636b7885fe051ce4ad8f5af864747a25cb503bd967602d842f",
+                "Result": True,
+                "errno": 0,  # Correct
+            },
+            {
+                "COUNT": "14",
+                "dsCAVS": "7b5a0c9338413287ea6175859ee1fe3bb93e6cc136d520381fc0594d051e46cb",
+                "QsCAVSx": "240921ef16b8ab315ca72b2d09cdc09499bf481e481a572fdc22fb50bed5a412",
+                "QsCAVSy": "b59f08b23a445458ada3a776e964989add7a29ec8526a6c2966a5b04ba69dbd2",
+                "deIUT": "994177e5a54fb2774329e51e239d81faba9d30376d40a6e711c22c08556d8fe9",
+                "QeIUTx": "c38dc31156a6ff5ab4f364d530e71c9635210bff3fd4260aa9901ec3195b5a75",
+                "QeIUTy": "1c795267f9cb10cbafd0c5677b4cd1180230222e70b865085e7c405a447ab2ed",
+                "CCMNonce": "f4f87261abfa320c294257e9ef",
+                "OI": (
+                    "a1b2c3d4e5434156536964ef7968a5c316899ffe293df3ebe5c27d491b72b9f1"
+                    "508c7bb91337e0978ec4840a5a34f5"
+                ),
+                "CAVSTag": "495f3033b4113b6774709ce03abb931c",
+                "Z": "7409911f0a73fa2f8ffaabfd4df421c911b8e34e5df6587b897713feb7f5443f",
+                "MacData": (
+                    "4b435f315f56434156536964a1b2c3d4e5c38dc31156a6ff5ab4f364d530e71c"
+                    "9635210bff3fd4260aa9901ec3195b5a751c795267f9cb10cbafd0c5677b4cd1"
+                    "180230222e70b865085e7c405a447ab2ed"
+                ),
+                "DKM": "0360c8b28d94724cc0172ab253c8be32c97e401e5acbb8f6156a197b2f0b1a5c",
+                "Result": True,
+                "errno": 0,  # Correct
+            },
+            {
+                "COUNT": "15",
+                "dsCAVS": "1c9cf449e0c26bac6e53434bb1eb1109b0d949ade949a7f3f5cf959ec3efb151",
+                "QsCAVSx": "a23277ff06cedfd9af5830e76ec21f622c055e1980da8fe3e4bdc4890ba6c0ec",
+                "QsCAVSy": "9fb7e6e2d1e3340cb731032f774541866f5bb9e35ce02e94206deadf213762a0",
+                "deIUT": "e45ae4860d9ae551c636469b336a3e3359b60a37c9b33a5174195b5f3e24f119",
+                "QeIUTx": "87d59e270162c1e3eee1a67222b0bb6af2637f161e668417f27bfab1d05ee64c",
+                "QeIUTy": "774c4cde652b6e36b812750237095ea98545e396eafd49cda93eee6fb673f61a",
+                "CCMNonce": "d54418e97be4bd9fa3cb2a368a",
+                "OI": (
+                    "a1b2c3d4e5434156536964b3b8d667a410941cf70143c907cc334ad1c86b5daa"
+                    "4cf8a82dcf85fe784e2cde98ef8c3c"
+                ),
+                "CAVSTag": "67a06652bec05456987e7106a1cdc593",
+                "Z": "92d8b21a9597ce23fb5d2a9db40c5e91b8865f7ba70e514ae19f5ac529e84af7",
+                "MacData": (
+                    "4b435f315f56434156536964a1b2c3d4e587d59e270162c1e3eee1a67222b0bb"
+                    "6af2637f161e668417f27bfab1d05ee64c774c4cde652b6e36b812750237095e"
+                    "a98545e396eafd49cda93eee6fb673f61a"
+                ),
+                "DKM": "bea6569ce5c30133a0f9cbd81bcfc5ac66dbcd256281d6c750f10cde0428d07e",
+                "Result": False,
+                "errno": 1,  # CAVS's Static public key X fails PKV 5.6.2.5
+            },
+            # Skipping COUNT=16 as we aren't checking Z, only DKM = KDF(Z)
+            {
+                "COUNT": "17",
+                "dsCAVS": "73f055106659418828c485dababab048802765ded1f457a33126573749578157",
+                "QsCAVSx": "cf9daa70272378942c127163161da82f140b7ce28371dbed0c6ee88dd65c4756",
+                "QsCAVSy": "e03f9915ca4dd2a92ed8a3db179d18d847b1105c17cbf02c9d3a5a273f5f897c",
+                "deIUT": "ad0183ed9996fea214e311e6f08a51e4fca21192f698ed8ec6c0dac96559f441",
+                "QeIUTx": "54c7b5b1b017a9a078f467b35ec7f5755d9f8332cc5b94838fb165f739bccf21",
+                "QeIUTy": "66934f95868fa0d3b64eef8a2840594c27cb5ca2d1ad548e963a997968be1bec",
+                "CCMNonce": "65cef6472a6c8f5b8caed4af6a",
+                "OI": (
+                    "a1b2c3d4e5434156536964badfa17a83dede5673c05abcf55e5c652f4bf7a673"
+                    "ad8ee8d64c98581ee9a1e0e2d19155"
+                ),
+                "CAVSTag": "3ef8605dbf1be9827f2475c348841961",
+                "Z": "f2928b050b6f1eccdc16f8ca0b8f9b76211308e60f17ab9360b3ed26e14043fe",
+                "MacData": (
+                    "4b435f315f56434156536964a1b2c3d4e554c7b5b1b017a9a078f467b35ec7f5"
+                    "755d9f8332cc5b94838fb165f739bccf2166934f95868fa0d3b64eef8a284059"
+                    "4c27cb5ca2d1ad548e963a997968be1bec"
+                ),
+                "DKM": "79baea0d4c3bf2d595fc7ea4992bfe80b54e23bce6e9615b103d0059c8e0a1d7",
+                "Result": False,
+                "errno": 2,  # CAVS's Static public key Y fails PKV 5.6.2.5
+            },
+            {
+                "COUNT": "18",
+                "dsCAVS": "971628ddadbcddfb922e70287a9adbfa30f7ac6bb2701a87527bec6e88ec1316",
+                "QsCAVSx": "9868a83022febb4cab175df1e934245a25d095e50409f73b5d7a36097ff94d81",
+                "QsCAVSy": "0eb09f73a870bd27b21d545a1baeed4936ad2ebd3ca9c7669fb2243710126a9f",
+                "deIUT": "0df0aea34080f8618095381af570a8bdea639fc33aab814a3b3fffd7ede96067",
+                "QeIUTx": "abcc7d56962bf462f73f7f503be442dd50f7faf4a94ae4e12f1576960b8596d2",
+                "QeIUTy": "c67c4ba91ee820717085de45583c1093a8b47bb534607b3a85075d0303e2db1e",
+                "CCMNonce": "9f52311f65537aa4f68284feba",
+                "OI": (
+                    "a1b2c3d4e54341565369649800d0f9a3664ac6ca8475f46f4562e4c22b574fe2"
+                    "e6167f452562bf59acc0106ba67b1d"
+                ),
+                "CAVSTag": "b41648c98a7f07c644451e951cdf3522",
+                "Z": "0a91f19edbd51ce5263d47deebca3b3b155751c7eb8157aade1205b850175bc7",
+                "MacData": (
+                    "4b435f315f56434156536964a1b2c3d4e5abcc7d56962bf462f73f7f503be442"
+                    "dd50f7faf4a94ae4e12f1576960b8596d2c67c4ba91ee820717085de45583c10"
+                    "93a8b47bb534607b3a85075d0303e2db1e"
+                ),
+                "DKM": "13894d83f2ccccd3b63f7fcbcc4fb025e734032b9e520fab5a1328c0cc38c5cc",
+                "Result": True,
+                "errno": 13,  # Z value should have leading 0 nibble
+            },
+            {
+                "COUNT": "19",
+                "dsCAVS": "c4065b9085d4c0f38d9aa7d6866e4230771d1714575a1a432f9a676b001e36b3",
+                "QsCAVSx": "d7b7298026823282ff8368bdd400eedde82a28ca704c311e408fdf4b40effde5",
+                "QsCAVSy": "94b17296022f27ba3f8f09ab513cc396a02a4378c8a44162e3924dd026cb4528",
+                "deIUT": "333caadc8cba879cc7cc94f2f6ca7be7500257ad0b6457119053cd73f3277207",
+                "QeIUTx": "a369487909814fc3399d4037e463fe807134403b8943533126856284149058a6",
+                "QeIUTy": "0b9ec2046c697e28323693b8a6d9e765df48d90f443cce26a8e6e0fe0131c758",
+                "CCMNonce": "b80ffb92260d5d8f0436e53a84",
+                "OI": (
+                    "a1b2c3d4e54341565369640be13e370c7fc1ddd14e380cc91324cf2a381df1da"
+                    "1ccffd90ae436a373a600f9383b1dd"
+                ),
+                "CAVSTag": "6aacfe0fe8e7fb562769107bf5980b42",
+                "Z": "f1a74f5c0d4ceeecd1cb15068df73e64858f6f7a40ac90ba3bce867e34f7834f",
+                "MacData": (
+                    "4b435f315f56434156536964a1b2c3d4e5a369487909814fc3399d4037e463fe"
+                    "807134403b8943533126856284149058a60b9ec2046c697e28323693b8a6d9e7"
+                    "65df48d90f443cce26a8e6e0fe0131c758"
+                ),
+                "DKM": "c90694e1f6b75611f6e44c4d7603a1ffc78c09896c1187e0ab43f4d5b5739e51",
+                "Result": True,
+                "errno": 0,  # Correct
+            },
+            {
+                "COUNT": "20",
+                "dsCAVS": "bf3b432d3b64d3b7d29b12b8335beb761e7e022d34a9c20b0e6133c7a0b6ecef",
+                "QsCAVSx": "332873f5e7dc386db059b28d996dee0a3b11245824f02e063b0fe0e895195281",
+                "QsCAVSy": "cd22fb45af7d19facccd33173a87fa7bbd3959ebcdde72d94b0b266174c9b387",
+                "deIUT": "0e82fd1c88b2aeb384245851caa51d7ebca66df34afc6739e61e570d0f163d78",
+                "QeIUTx": "90f5d3f7c714c81cae4a0262d9ce8629fe85c98f929d774a209c1ebf195a4bca",
+                "QeIUTy": "2df3b49280fa430cc0ed8acf1a3afe740a7804894fb45a844950f36f85cecc45",
+                "CCMNonce": "50cb421524d1f00f6f893b12f9",
+                "OI": (
+                    "a1b2c3d4e543415653696412eb216d2fa9e95304d4aa8b2c2d71fdbff7c5251b"
+                    "ac8b65e4f027a049c3e40489fa9627"
+                ),
+                "CAVSTag": "7adb86cb75dc6b22d6f9b32a801e41e9",
+                "Z": "3d3885b2fe181192165a54b02f7c1de7a7c494c96c350fd6d36a3d1ca712a1c8",
+                "MacData": (
+                    "4b435f315f56434156536964a1b2c3d4e590f5d3f7c714c81cae4a0262d9ce86"
+                    "29fe85c98f929d774a209c1ebf195a4bca2df3b49280fa430cc0ed8acf1a3afe"
+                    "740a7804894fb45a844950f36f85cecc45"
+                ),
+                "DKM": "9b71b952154b63142770f23c6c8dedc334bf9acaf36f1845c03268196ba1dfa2",
+                "Result": True,
+                "errno": 0,  # Correct
+            },
+            # Not sure why COUNT=21 is marked as "DKM changed", as DKM matches expected. May be
+            # a part of key validation
+            {
+                "COUNT": "22",
+                "dsCAVS": "bc273e80f489d70ed8c1da068fe20719384b498076cc780961ba69ba8c9e00b3",
+                "QsCAVSx": "5601052c06b3a8b59396cf21be1925da225713ee4d415c778810baaeedcb667e",
+                "QsCAVSy": "188aa7435b4207ae4db522414631b15b184113e45066b9f15e2e2f0d2e130a5c",
+                "deIUT": "f47d59a75c44202994e0feebad7e9f9861b6a01eb1738125648536c052c824b6",
+                "QeIUTx": "ba6783db86321ab1a957e0dd45d9033dfafdefc5d2090d4e229c49004268505b",
+                "QeIUTy": "aea1bfcc190d33834aaf1ae4bbd0a6dc06dedddf061daf4ab4a23cd7118bda75",
+                "CCMNonce": "d22480e4fcdcf5ebfae9f99af4",
+                "OI": (
+                    "a1b2c3d4e5434156536964d0ea4c09565268f8fe3b46d251ddce31933b85d398"
+                    "a90340da8ca7adc86289216002b0d6"
+                ),
+                "CAVSTag": "c4b056c07a3b1f4a4770a0dadbffe330",
+                "Z": "e599dfd15aa5b3875ba8a30696ba53252321625553b9a907897f60b6b7c7b7ea",
+                "MacData": (
+                    "4b435f315f56434156536964a1b2c3d4e5ba6783db86321ab1a957e0dd45d903"
+                    "3dfafdefc5d2090d4e229c49004268505baea1bfcc190d33834aaf1ae4bbd0a6"
+                    "dc06dedddf061daf4ab4a23cd7118bda75"
+                ),
+                "DKM": "1febe90df557326deb2c3424895c1c4c4a1efedb69628d3117573287dfbedb43",
+                "Result": True,
+                "errno": 0,  # Correct
+            },
+            # Not using COUNT=23  as we are not doing key validation
+            {
+                "COUNT": "24",
+                "dsCAVS": "af80ece61de5bd77849ca9edc6d867c8a5920e8a0b9a717b6e6f4192f5a4ba21",
+                "QsCAVSx": "7cba6558453fe19e641fbde76d3c5987c0bdc845d9cbdd5f41fa29c27ad8bde0",
+                "QsCAVSy": "d7bf2539f39a6ece292b5ddc455ed829c750575b29be343f02e5058b59637677",
+                "deIUT": "3b92f74f8c40ac09575e282cb45bd64d530e153255474c9aa35d0874f0543e56",
+                "QeIUTx": "58558d3e7ecb148aa0cc19d8aa3de175b8eb5eaf3965d4c2155900424a0c29fa",
+                "QeIUTy": "b35bc5f7058fc788a5cfd7f566e103e71b0f118357bd1e0ee7996903a38d7acd",
+                "CCMNonce": "d138db9ebed322bcceacc39938",
+                "OI": (
+                    "a1b2c3d4e543415653696486607205e3b85cb5d03c2a7a2c624c9c76bcda5d31"
+                    "cd1d738d1b51bc4385a92ec1d7940d"
+                ),
+                "CAVSTag": "0fcaefcce356c5186fade5b13e1eb33a",
+                "Z": "ae80f8f68b7db1e8232378bbfd016d06232f16e7869218158d9357fac8868571",
+                "MacData": (
+                    "4b435f315f56434156536964a1b2c3d4e558558d3e7ecb148aa0cc19d8aa3de1"
+                    "75b8eb5eaf3965d4c2155900424a0c29fab35bc5f7058fc788a5cfd7f566e103"
+                    "e71b0f118357bd1e0ee7996903a38d7acd"
+                ),
+                "DKM": "700894558d6af3e0efc1d08cca8bcec2ac619dab53bbab5be522f74b62821f63",
+                "Result": True,
+                "errno": 0,  # Correct
+            },
+            {
+                "COUNT": "25",
+                "dsCAVS": "f65ce6e3eb5b0fcd2c224dab57629123df1c59d42b7a5114678b92f3b7a5a209",
+                "QsCAVSx": "21c1d079a835f4e6ed38d76719bfb959170817f651b79ee92ed944cba5441797",
+                "QsCAVSy": "79dc92df057f64f98a890cd28571384beec168e12d2d7494ba7b22cd136fdc6b",
+                "deIUT": "b4b60bdc4577714c8cfa3acfb38917b3c5d7564d560c5530d7d98dc8b8da8991",
+                "QeIUTx": "e19680b60d5d6d532e7542603662e1ba947a67363977cb07da1d90c811c4192f",
+                "QeIUTy": "3d4aa730c26637fcdb9af0e74f61bc8b0a16bbcec3611baa93aad7decba4db61",
+                "CCMNonce": "6b2a14d5493b2901c20f29cd3a",
+                "OI": (
+                    "a1b2c3d4e5434156536964cd161f482fbff2a2eb7456287d92c6c048bde3ce2c"
+                    "25b09d5a0701016776313aa05b141c"
+                ),
+                "CAVSTag": "56c3a514f3c189e6ff41700d71fdfcb9",
+                "Z": "ca1dd4ea3fcd2636216caea121fefa9a7243e0c874140c563bdf89899b0d096a",
+                "MacData": (
+                    "4b435f315f56434156536964a1b2c3d4e5e19680b60d5d6d532e7542603662e1"
+                    "ba947a67363977cb07da1d90c811c4192f3d4aa730c26637fcdb9af0e74f61bc"
+                    "8b0a16bbcec3611baa93aad7decba4db61"
+                ),
+                "DKM": "bd7425c3b573e5569bd92e82f3c35f76ae0705e58b6c9e6563746c7fc85716dd",
+                "Result": True,
+                "errno": 0,  # Correct
+            },
+            {
+                "COUNT": "26",
+                "dsCAVS": "3e9cecdd90fb68f446cc9503cf538a061b6923f56428449a3aad3d24a0654080",
+                "QsCAVSx": "1e2a99aa1d36c64b83d0eb301427a2e9144c795846832e681015c0b316ad22bf",
+                "QsCAVSy": "34490b9ad244fa0ec0981ed6daebecd8435da5f77a25ffa9be9385b7f44b804d",
+                "deIUT": "54a8c21fa068c0e9acaad084293a9324394f972264dd2222b136888136d77bc3",
+                "QeIUTx": "81eaa64483e11cac4cfa55042c9073af8e658a6551ca12228aa150238b674533",
+                "QeIUTy": "7cc75e8a521b548b685821ce32d5cc63cd6f179ea1790050b3efdac18a98d3fd",
+                "CCMNonce": "edb1af87767585d74dd9d7aabc",
+                "OI": (
+                    "a1b2c3d4e5434156536964b2225bc72f2233f1d30a3ccf8e1b86c091d06c42b3"
+                    "b51864147c4a7e004e541f165f6a47"
+                ),
+                "CAVSTag": "5236954327fd1c772204b6c80fdd81d9",
+                "Z": "8f1c402476a1ce5482e1f20c9400fddd370846ed15107716cefc679a243e743d",
+                "MacData": (
+                    "4b435f315f56434156536964a1b2c3d4e581eaa64483e11cac4cfa55042c9073"
+                    "af8e658a6551ca12228aa150238b6745337cc75e8a521b548b685821ce32d5cc"
+                    "63cd6f179ea1790050b3efdac18a98d3fd"
+                ),
+                "DKM": "0cd80e81897a7d69a735cc34c93230d0bd5df4d29976016c914ef2ab2bb138ee",
+                "Result": True,
+                "errno": 14,  # DKM value should have leading 0 nibble
+            },
+            {
+                "COUNT": "27",
+                "dsCAVS": "2c807902a704c607ff5ced6240eaaed76be93ab5277fd1a35d8835801b805912",
+                "QsCAVSx": "99300c5b854b338eb5ad4fc1d37b39193c063f8ed2b886b77532a7866a88631b",
+                "QsCAVSy": "6b1006910ed0c30b8a203f066e5ec0aa486437f81f6f8a8fe6c5e80a675bd0d7",
+                "deIUT": "ec39d15b74c62ddbc04147f6901b67265bf259f556bebb3c15e42e3800db5081",
+                "QeIUTx": "4d01a3cecc758d5d31b74583fe990f93dd8867664a7eae7d919c60a5017fa6a4",
+                "QeIUTy": "516f995f57d01c3290e9fb3432c1eec5c2312c2e251eb414a1516d9bd1a2dd44",
+                "CCMNonce": "fc68adb6c01fbe1d0141ee0fe4",
+                "OI": (
+                    "a1b2c3d4e5434156536964e788d9f273bdeee54e54f1bf56c259b046e36195dc"
+                    "8f51283b6f00748e0e978dee33977d"
+                ),
+                "CAVSTag": "06e9fc35b4b50bc6987ce020c313d665",
+                "Z": "50f6ee49c690f2e5b01ba70011cc88575f8a4d41d44fd244f97fd7f3ed73cb04",
+                "MacData": (
+                    "4b435f315f56434156536964a1b2c3d4e54d01a3cecc758d5d31b74583fe990f"
+                    "93dd8867664a7eae7d919c60a5017fa6a4516f995f57d01c3290e9fb3432c1ee"
+                    "c5c2312c2e251eb414a1516d9bd1a2dd44"
+                ),
+                "DKM": "0d30b098fe0bda5394d5ef97b03ef2c556a52793431fbbdafb350a350c6de04e",
+                "Result": True,
+                "errno": 0,  # Correct
+            },
+            # Not using COUNT=28  as we are not doing key validation
+            # Not sure why COUNT=29 works, when it shouldn't, may be testing key validation
+        ]
+
+        class _TestKeypair(keychain.Keypair):
+            def _calc_otherinfo(self, algorithm, party_u_info, party_v_info):
+                return self._otherinfo
+
+        for vec in _CAVS_VECTORS:
+            logger.debug('COUNT=%s, Result=%s/%s', vec['COUNT'], vec['Result'], vec['errno'])
+            otherinfo = bytes(bytearray.fromhex(vec['OI']))
+
+            ue_jwk = {
+                "kty": "EC",
+                "crv": "P-256",
+                "x": utils.base64url_encode(bytearray.fromhex(vec['QeIUTx'])),
+                "y": utils.base64url_encode(bytearray.fromhex(vec['QeIUTy'])),
+                "d": utils.base64url_encode(bytearray.fromhex(vec['deIUT'])),
+            }
+            u_private_keypair = _TestKeypair.from_jwk(ue_jwk)
+            u_private_keypair._otherinfo = otherinfo
+            u_public_keypair = _private_to_public(u_private_keypair)
+
+            vs_jwk = {
+                "kty": "EC",
+                "crv": "P-256",
+                "x": utils.base64url_encode(bytearray.fromhex(vec['QsCAVSx'])),
+                "y": utils.base64url_encode(bytearray.fromhex(vec['QsCAVSy'])),
+                "d": utils.base64url_encode(bytearray.fromhex(vec['dsCAVS'])),
+            }
+
+            if not vec['Result'] and vec['errno'] in [1, 2]:
+                with self.assertRaises(ValueError):
+                    v_private_keypair = _TestKeypair.from_jwk(vs_jwk)
+                    v_private_keypair._otherinfo = otherinfo
+                    # v_public_keypair = _private_to_public(v_private_keypair)
+            else:
+                v_private_keypair = _TestKeypair.from_jwk(vs_jwk)
+                v_private_keypair._otherinfo = otherinfo
+                v_public_keypair = _private_to_public(v_private_keypair)
+
+                ku = u_private_keypair.ecdh(v_public_keypair)
+                kv = v_private_keypair.ecdh(u_public_keypair)
+
+                self.assertEqual(len(ku), 32)
+                self.assertEqual(len(kv), 32)
+
+                if vec['Result']:
+                    dkm = bytes(bytearray.fromhex(vec['DKM']))
+                    self.assertEqual(len(dkm), 32)
+
+                    self.assertEqual(ku, dkm)
+                    self.assertEqual(kv, dkm)
+
+                    eve_keypair = service.create_secret_key()
+                    keve = eve_keypair.ecdh(u_private_keypair)
+                    self.assertNotEqual(ku, keve)
+                else:
+                    self.assertNotEqual(ku, kv)

--- a/tests/test_keychain.py
+++ b/tests/test_keychain.py
@@ -10,7 +10,7 @@ import unittest
 
 from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePublicKey
 
-from oneid import keychain, utils
+from oneid import keychain, service, utils
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 class TestCredentials(unittest.TestCase):
     def setUp(self):
         self.uuid = uuid.uuid4()
-        self.keypair = keychain.Keypair()
+        self.keypair = service.create_secret_key()
 
     def test_basic_object(self):
         creds = keychain.Credentials(self.uuid, self.keypair)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -228,3 +228,41 @@ class TestEncryptDecryptAttributes(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             service.decrypt_attr_value(enc, self.key)
+
+
+class TestKeyWrapUnwrap(unittest.TestCase):
+    def setUp(self):
+        # arbitrary set of NIST CAVP vectors via pyca/cryptography/.../KW_AD_256.txt
+        self.vectors = [
+            {
+                'count': 21,
+                'key': 'd17c69d99de8ef419806e217d2beb10c439628b0252324534c7029659f5d0d51',
+                'ciphertext': '4c46d20b3ef76d466ff16049227afbfa012ab04545164310',
+                'plaintext': '819e142888ea323a3f127ddc972aa23f',
+            },
+            {
+                'count': 22,
+                'key': '71e9abf9daed93b6a1565ce1e0aeecf5945bc9b65c330f853acd91b9c760ed5a',
+                'ciphertext': '8e3dc40df3fe168b29dd687b557edf7539927734ad502a85',
+                'plaintext': '4e7b85ac4548230362e615b6e7e081f9',
+            },
+            {
+                'count': 23,
+                'key': '2dc77923638672c4ae42886e9c11fe84767bc0bcb12dd9e46cb43d35a4d550cb',
+                'ciphertext': '267fe9821e5a7981ff1d698ad7be09a50d629155ee723c73',
+                'plaintext': '685b0c79c092bce176b6eb7d91eff334',
+            },
+        ]
+
+    def tearDown(self):
+        pass
+
+    def test_wrap_unwrap(self):
+        for vector in self.vectors:
+            logger.debug('count=%s', vector['count'])
+            key = bytes(bytearray.fromhex(vector['key']))
+            ciphertext = bytes(bytearray.fromhex(vector['ciphertext']))
+            plaintext = bytes(bytearray.fromhex(vector['plaintext']))
+
+            self.assertEqual(service.key_wrap(key, plaintext), ciphertext)
+            self.assertEqual(service.key_unwrap(key, ciphertext), plaintext)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -6,7 +6,7 @@ import mock
 
 from cryptography.exceptions import InvalidSignature
 
-from oneid import session, service, keychain, jwts, nonces, exceptions
+from oneid import session, service, keychain, jose, jwts, jwes, nonces, exceptions
 
 logger = logging.getLogger(__name__)
 
@@ -129,6 +129,18 @@ class TestBaseSession(unittest.TestCase):
                           "GET",
                           "https://myservice/unauthorized")
 
+    def test_peer_credentials(self):
+        base = session.SessionBase()
+        self.assertIsNone(base.peer_credentials)
+
+        cred = keychain.Credentials('me', keychain.BaseKeypair())
+
+        base = session.SessionBase(peer_credentials=cred)
+        self.assertIsInstance(base.peer_credentials, list)
+
+        base = session.SessionBase(peer_credentials=[cred])
+        self.assertIsInstance(base.peer_credentials, list)
+
 
 class TestDeviceSession(unittest.TestCase):
     def setUp(self):
@@ -161,6 +173,15 @@ class TestDeviceSession(unittest.TestCase):
         self.oneid_credentials = keychain.Credentials(
             self.mock_oneid_keypair.identity,
             self.mock_oneid_keypair
+        )
+
+        mock_peer_keypair = keychain.Keypair.from_secret_pem(
+            key_bytes=TestSession.alt_key_bytes
+        )
+        mock_peer_keypair.identity = 'peer'
+
+        self.peer_credentials = keychain.Credentials(
+            mock_peer_keypair.identity, mock_peer_keypair
         )
 
         self.mock_resetA_keypair = keychain.Keypair.from_secret_pem(
@@ -201,6 +222,32 @@ class TestDeviceSession(unittest.TestCase):
         jws = sess.prepare_message(a=1)
 
         claims = jwts.verify_jws(jws, self.id_credentials.keypair)
+
+        self.assertIsInstance(claims, dict)
+        self.assertIn("a", claims)
+        self.assertEqual(claims.get("a"), 1)
+
+    def test_prepare_message_encrypted_session(self):
+        sess = session.DeviceSession(self.id_credentials, peer_credentials=self.peer_credentials)
+        jws = sess.prepare_message(a=1)
+
+        jwe = jwts.verify_jws(jws, self.id_credentials.keypair)
+        self.assertTrue(jose.is_jwe(jwe))
+
+        claims = jwes.decrypt_jwe(jwe, self.peer_credentials.keypair)
+
+        self.assertIsInstance(claims, dict)
+        self.assertIn("a", claims)
+        self.assertEqual(claims.get("a"), 1)
+
+    def test_prepare_message_encrypted_to_other(self):
+        sess = session.DeviceSession(self.id_credentials)
+        jws = sess.prepare_message(a=1, other_recipients=[self.peer_credentials])
+
+        jwe = jwts.verify_jws(jws, self.id_credentials.keypair)
+        self.assertTrue(jose.is_jwe(jwe))
+
+        claims = jwes.decrypt_jwe(jwe, self.peer_credentials.keypair)
 
         self.assertIsInstance(claims, dict)
         self.assertIn("a", claims)
@@ -263,6 +310,23 @@ class TestDeviceSession(unittest.TestCase):
         self.assertIsInstance(claims, dict)
         self.assertIn("d", claims)
         self.assertEqual(claims.get("d"), 4)
+
+    def test_verify_encrypted_session_message(self):
+        jwe = jwes.make_jwe(
+            {'b': 2},
+            self.proj_credentials.keypair,
+            self.id_credentials.keypair,
+            jsonify=False,
+        )
+        jws = jwts.make_jws(jwe, [self.mock_proj_keypair, self.mock_oneid_keypair])
+
+        sess = session.DeviceSession(
+            self.id_credentials, self.proj_credentials, self.oneid_credentials
+        )
+        claims = sess.verify_message(jws)
+        self.assertIsInstance(claims, dict)
+        self.assertIn("b", claims)
+        self.assertEqual(claims.get("b"), 2)
 
 
 class TestServerSession(unittest.TestCase):
@@ -403,6 +467,34 @@ class TestServerSession(unittest.TestCase):
         self.assertIn('a', verified)
         self.assertIn('b', verified)
 
+    @mock.patch('oneid.session.request', side_effect=mock_request)
+    def test_prepare_message_encrypted_session(self, mock_request):
+        peer_credentials = self.alt_credentials
+        sess = session.ServerSession(
+            identity_credentials=self.id_credentials,
+            oneid_credentials=self.oneid_credentials,
+            project_credentials=self.project_credentials,
+            peer_credentials=peer_credentials,
+            config=self.fake_config,
+        )
+
+        jws = sess.prepare_message(
+            a=1, b=2,
+        )
+
+        keypairs = [
+            self.oneid_credentials.keypair,
+            self.project_credentials.keypair,
+        ]
+
+        jwe = jwts.verify_jws(jws, keypairs)
+
+        claims = jwes.decrypt_jwe(jwe, peer_credentials.keypair)
+
+        self.assertIsInstance(claims, dict)
+        self.assertIn('a', claims)
+        self.assertIn('b', claims)
+
     @mock.patch('oneid.session.request', side_effect=mock_failed_cosign_request)
     def test_prepare_message_failed_cosign(self, mock_request):
         sess = session.ServerSession(
@@ -519,6 +611,26 @@ class TestServerSession(unittest.TestCase):
         claims = sess.verify_message(
             message, self.id_credentials, get_oneid_cosignature=False
         )
+        self.assertIsInstance(claims, dict)
+        self.assertIn("c", claims)
+        self.assertEqual(claims.get("c"), 3)
+
+    @mock.patch('oneid.session.request', side_effect=mock_request)
+    def test_verify_message_jwe(self, mock_request):
+        jwe = jwes.make_jwe(
+            {'c': 3},
+            self.id_credentials.keypair,
+            self.alt_credentials.keypair,
+            jsonify=False,
+        )
+        message = jwts.make_jws(jwe, [self.id_credentials.keypair])
+        sess = session.ServerSession(
+            identity_credentials=self.alt_credentials,
+            oneid_credentials=self.oneid_credentials,
+            project_credentials=self.project_credentials,
+            config=self.fake_config,
+        )
+        claims = sess.verify_message(message, self.id_credentials)
         self.assertIsInstance(claims, dict)
         self.assertIn("c", claims)
         self.assertEqual(claims.get("c"), 3)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,11 @@
 
 from __future__ import unicode_literals
 
+import time
 import logging
+
+from datetime import datetime
+from dateutil import tz
 
 from unittest import TestCase
 
@@ -26,6 +30,23 @@ class TestBytesStringConverters(TestCase):
     def test_to_string(self):
         self.assertEqual(self.str_thing, utils.to_string(self.str_thing))
         self.assertEqual(self.str_thing, utils.to_string(self.bytes_thing))
+
+
+class TestTimestampConverters(TestCase):
+    def setUp(self):
+        self.ts = int(time.time())
+        self.dt = datetime.fromtimestamp(self.ts, tz.tzutc())
+        self.iso_dt = self.dt.isoformat()
+
+    def tearDown(self):
+        pass
+
+    def test_to_timestamp(self):
+        self.assertEqual(utils.to_timestamp(self.dt), self.ts)
+        self.assertEqual(utils.to_timestamp(self.iso_dt), self.ts)
+
+    def test_from_timestamp(self):
+        self.assertEqual(utils.from_timestamp(self.ts), self.dt)
 
 
 class TestBase64URL(TestCase):


### PR DESCRIPTION
Add the ability to encrypt and decrypt messages to/from specific identities.

Adds:
- JWK formats in KeyPairs
- AES KeyWrap mode for encrypting keys
- ECDH static-ephemeral key exchange
- JWEs for directed messages
- JWEs for simple AES encryption (augments format SJCL uses)
- Ability to transparently encrypt Sessions