### PR TITLE
Assume encrypted messages are intended for Project

### DIFF
--- a/src/oneid/session.py
+++ b/src/oneid/session.py
@@ -318,7 +318,12 @@ class ServerSession(SessionBase):
         ret = jwts.verify_jws(message, keypairs)
 
         if jose.is_jwe(ret):
-            ret = jwes.decrypt_jwe(ret, self.identity_credentials.keypair)
+            try:
+                # the message is most likely intended for the Project
+                ret = jwes.decrypt_jwe(ret, self.project_credentials.keypair)
+            except exceptions.InvalidRecipient:
+                # but in case it is intended for the Project Server itself
+                ret = jwes.decrypt_jwe(ret, self.identity_credentials.keypair)
 
         return ret
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -616,7 +616,27 @@ class TestServerSession(unittest.TestCase):
         self.assertEqual(claims.get("c"), 3)
 
     @mock.patch('oneid.session.request', side_effect=mock_request)
-    def test_verify_message_jwe(self, mock_request):
+    def test_verify_message_project_jwe(self, mock_request):
+        jwe = jwes.make_jwe(
+            {'c': 3},
+            self.id_credentials.keypair,
+            self.project_credentials.keypair,
+            jsonify=False,
+        )
+        message = jwts.make_jws(jwe, [self.id_credentials.keypair])
+        sess = session.ServerSession(
+            identity_credentials=self.alt_credentials,
+            oneid_credentials=self.oneid_credentials,
+            project_credentials=self.project_credentials,
+            config=self.fake_config,
+        )
+        claims = sess.verify_message(message, self.id_credentials)
+        self.assertIsInstance(claims, dict)
+        self.assertIn("c", claims)
+        self.assertEqual(claims.get("c"), 3)
+
+    @mock.patch('oneid.session.request', side_effect=mock_request)
+    def test_verify_message_project_server_jwe(self, mock_request):
         jwe = jwes.make_jwe(
             {'c': 3},
             self.id_credentials.keypair,


### PR DESCRIPTION
Changes to ServerSession to check encrypted messages against the Project keys before their own, as in most cases, Servers will be getting Project-directed messages, not messages intended for them alone.