### PR TITLE
[ONEID-534] Prefer 96-bit IV

### DIFF
--- a/src/oneid/__about__.py
+++ b/src/oneid/__about__.py
@@ -11,7 +11,7 @@ __summary__ = ("oneID-connect is an identity & authentication "
 
 __uri__ = "https://github.com/OneID/oneID-connect-python"
 
-__version__ = "0.17.3-dev1"
+__version__ = "0.17.3-dev2"
 
 __author__ = "oneID Inc."
 __email__ = "support@oneID.com"

--- a/src/oneid/keychain.py
+++ b/src/oneid/keychain.py
@@ -4,6 +4,8 @@ A Keypair is used to sign and verify signatures
 
 Keys should be kept in a secure storage enclave.
 """
+from __future__ import division
+
 import struct
 import logging
 

--- a/src/oneid/keychain.py
+++ b/src/oneid/keychain.py
@@ -75,15 +75,11 @@ class ProjectCredentials(Credentials):
         """
         return symcrypt.aes_encrypt(plain_text, self._encryption_key)
 
-    def decrypt(self, cipher_text, iv=None, cipher='aes', mode='gcm', tag_size=128):
+    def decrypt(self, cipher_text):
         """
         Decrypt cipher text that was encrypted with the project encryption key
 
-        :param cipher_text: Encrypted text or dict (as returned by :py:encrypt:)
-        :param iv: Base64 encoded initialization vector
-        :param cipher: [deprecated]
-        :param mode: [deprecated]
-        :param tag_size: [deprecated]
+        :param cipher_text: Encrypted dict as returned by :py:encrypt:
         :returns: plain text
         :return_type: bytes
         """

--- a/src/oneid/service.py
+++ b/src/oneid/service.py
@@ -7,21 +7,18 @@ keys, etc.
 from __future__ import unicode_literals
 
 import os
-import base64
 import re
 import logging
 
 from cryptography.hazmat.primitives.asymmetric import ec
-from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.serialization \
     import Encoding, PrivateFormat, NoEncryption
-from cryptography.hazmat.primitives.keywrap import aes_key_wrap, aes_key_unwrap
 
 from .keychain import Keypair
 from . import jwts
-from . import utils
 from . import file_adapter
+from . import symcrypt
 
 logger = logging.getLogger(__name__)
 
@@ -200,7 +197,7 @@ def create_aes_key():
 
     :return: Encryption key bytes
     """
-    return os.urandom(32)
+    return symcrypt.create_aes_key()
 
 
 def encrypt_attr_value(attr_value, aes_key, legacy_support=True):
@@ -211,32 +208,7 @@ def encrypt_attr_value(attr_value, aes_key, legacy_support=True):
     :param aes_key: symmetric key to encrypt attribute value with
     :return: Dictionary (Flattened JWE) with base64-encoded ciphertext and base64-encoded iv
     """
-    iv = os.urandom(16)
-    cipher_alg = Cipher(algorithms.AES(aes_key), modes.GCM(iv), backend=_BACKEND)
-    encryptor = cipher_alg.encryptor()
-    encr_value = encryptor.update(utils.to_bytes(attr_value)) + encryptor.finalize()
-    ciphertext_b64 = utils.base64url_encode(encr_value)
-    tag_b64 = utils.base64url_encode(encryptor.tag)
-    iv_b64 = base64.b64encode(iv) if legacy_support else utils.base64url_encode(iv)
-    ret = {
-      "header": {
-        "alg": "dir",
-        "enc": "A256GCM"
-      },
-      "iv": iv_b64,
-      "ciphertext": ciphertext_b64,
-      "tag": tag_b64,
-    }
-
-    if legacy_support:
-        ct_b64 = base64.b64encode(encr_value + encryptor.tag)
-        ret.update({
-          "cipher": "aes",
-          "mode": "gcm",
-          "ts": 128,
-          "ct": ct_b64,
-        })
-    return ret
+    return symcrypt.aes_encrypt(attr_value, aes_key, legacy_support)
 
 
 def decrypt_attr_value(attr_ct, aes_key):
@@ -248,46 +220,12 @@ def decrypt_attr_value(attr_ct, aes_key):
     :param aes_key: symmetric key to decrypt attribute value with
     :return: plaintext bytes
     """
-    if not isinstance(attr_ct, dict) or (
-        attr_ct.get('cipher', 'aes') != 'aes' or
-        attr_ct.get('mode', 'gcm') != 'gcm' or
-        (
-            'header' in attr_ct and (
-                attr_ct['header'].get('alg', 'dir') != 'dir' or
-                attr_ct['header'].get('env', 'A256GCM') != 'A256GCM'
-            )
-        )
-    ):
-        raise ValueError('invalid encrypted attribute')
-
-    iv = None
-    ciphertext = None
-
-    if 'ciphertext' in attr_ct:
-        # JWE included, prefer that
-        ciphertext = utils.base64url_decode(attr_ct.get('ciphertext'))
-        tag = utils.base64url_decode(attr_ct.get('tag'))
-        iv = utils.base64url_decode(attr_ct['iv'])
-    else:
-        # legacy only
-        iv = base64.b64decode(attr_ct['iv'])
-        tag_ct = base64.b64decode(attr_ct['ct'])
-        ts = attr_ct.get('ts', 64) // 8
-        ciphertext = tag_ct[:-ts]
-        tag = tag_ct[-ts:]
-
-    cipher_alg = Cipher(
-        algorithms.AES(aes_key),
-        modes.GCM(iv, tag, min_tag_length=8),
-        backend=_BACKEND
-    )
-    decryptor = cipher_alg.decryptor()
-    return decryptor.update(ciphertext) + decryptor.finalize()
+    return symcrypt.aes_decrypt(attr_ct, aes_key)
 
 
 def key_wrap(wrapping_key, key_to_wrap):
-    return aes_key_wrap(wrapping_key, key_to_wrap, _BACKEND)
+    return symcrypt.key_wrap(wrapping_key, key_to_wrap)
 
 
 def key_unwrap(wrapping_key, wrapped_key):
-    return aes_key_unwrap(wrapping_key, wrapped_key, _BACKEND)
+    return symcrypt.key_unwrap(wrapping_key, wrapped_key)

--- a/src/oneid/symcrypt.py
+++ b/src/oneid/symcrypt.py
@@ -39,7 +39,7 @@ def aes_encrypt(plaintext, aes_key, legacy_support=True):
     :param aes_key: symmetric key to encrypt attribute value with
     :return: Dictionary (Flattened JWE) with base64-encoded ciphertext and base64-encoded iv
     """
-    iv = os.urandom(16)
+    iv = os.urandom(12)
     cipher_alg = Cipher(algorithms.AES(aes_key), modes.GCM(iv), backend=_BACKEND)
     encryptor = cipher_alg.encryptor()
     encr_value = encryptor.update(utils.to_bytes(plaintext)) + encryptor.finalize()

--- a/src/oneid/symcrypt.py
+++ b/src/oneid/symcrypt.py
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+
+"""
+Provides useful functions for interacting with the oneID API, including creation of
+keys, etc.
+"""
+from __future__ import unicode_literals
+
+import os
+import base64
+import logging
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.primitives.keywrap import aes_key_wrap, aes_key_unwrap
+
+from . import utils
+
+logger = logging.getLogger(__name__)
+
+
+_BACKEND = default_backend()
+
+
+def create_aes_key():
+    """
+    Create an AES256 key for symmetric encryption
+
+    :return: Encryption key bytes
+    """
+    return os.urandom(32)
+
+
+def aes_encrypt(plaintext, aes_key, legacy_support=True):
+    """
+    Encrypt using AES-GCM
+
+    :param plaintext: (string or bytes) that you want encrypted
+    :param aes_key: symmetric key to encrypt attribute value with
+    :return: Dictionary (Flattened JWE) with base64-encoded ciphertext and base64-encoded iv
+    """
+    iv = os.urandom(16)
+    cipher_alg = Cipher(algorithms.AES(aes_key), modes.GCM(iv), backend=_BACKEND)
+    encryptor = cipher_alg.encryptor()
+    encr_value = encryptor.update(utils.to_bytes(plaintext)) + encryptor.finalize()
+    ciphertext_b64 = utils.base64url_encode(encr_value)
+    tag_b64 = utils.base64url_encode(encryptor.tag)
+    iv_b64 = base64.b64encode(iv) if legacy_support else utils.base64url_encode(iv)
+    ret = {
+      "header": {
+        "alg": "dir",
+        "enc": "A256GCM"
+      },
+      "iv": iv_b64,
+      "ciphertext": ciphertext_b64,
+      "tag": tag_b64,
+    }
+
+    if legacy_support:
+        ct_b64 = base64.b64encode(encr_value + encryptor.tag)
+        ret.update({
+          "cipher": "aes",
+          "mode": "gcm",
+          "ts": 128,
+          "ct": ct_b64,
+        })
+    return ret
+
+
+def aes_decrypt(attr_ct, aes_key):
+    """
+    Convenience method to decrypt attribute properties
+
+    :param attr_ct: Dictionary (may be a Flattened JWE) with base64-encoded
+        ciphertext and base64-encoded iv
+    :param aes_key: symmetric key to decrypt attribute value with
+    :return: plaintext bytes
+    """
+    if not isinstance(attr_ct, dict) or (
+        attr_ct.get('cipher', 'aes') != 'aes' or
+        attr_ct.get('mode', 'gcm') != 'gcm' or
+        'iv' not in attr_ct or
+        (
+            'header' in attr_ct and (
+                attr_ct['header'].get('alg', 'dir') != 'dir' or
+                attr_ct['header'].get('env', 'A256GCM') != 'A256GCM'
+            )
+        )
+    ):
+        raise ValueError('invalid encrypted attribute')
+
+    iv = None
+    ciphertext = None
+
+    if 'ciphertext' in attr_ct:
+        # JWE included, prefer that
+        ciphertext = utils.base64url_decode(attr_ct.get('ciphertext'))
+        tag = utils.base64url_decode(attr_ct.get('tag'))
+        iv = utils.base64url_decode(attr_ct['iv'])
+    else:
+        # legacy only
+        iv = base64.b64decode(attr_ct['iv'])
+        tag_ct = base64.b64decode(attr_ct['ct'])
+        ts = attr_ct.get('ts', 64) // 8
+        ciphertext = tag_ct[:-ts]
+        tag = tag_ct[-ts:]
+
+    cipher_alg = Cipher(
+        algorithms.AES(aes_key),
+        modes.GCM(iv, tag, min_tag_length=8),
+        backend=_BACKEND
+    )
+    decryptor = cipher_alg.decryptor()
+    return decryptor.update(ciphertext) + decryptor.finalize()
+
+
+def key_wrap(wrapping_key, key_to_wrap):
+    return aes_key_wrap(wrapping_key, key_to_wrap, _BACKEND)
+
+
+def key_unwrap(wrapping_key, wrapped_key):
+    return aes_key_unwrap(wrapping_key, wrapped_key, _BACKEND)

--- a/tests/test_keychain.py
+++ b/tests/test_keychain.py
@@ -56,7 +56,7 @@ class TestProjectCredentials(TestCredentials):
         self.assertEqual(enc.get("ts"), 128)
 
         cleartext = utils.to_string(
-            self.project_credentials.decrypt(enc['ct'], enc['iv'])
+            self.project_credentials.decrypt(enc)
         )
         self.assertEqual(cleartext, self.data)
 
@@ -67,15 +67,9 @@ class TestProjectCredentials(TestCredentials):
             logger.debug('enc/dec %s', text)
             enc = self.project_credentials.encrypt(text)
             cleartext = utils.to_string(
-                self.project_credentials.decrypt(enc['ct'], enc['iv'])
+                self.project_credentials.decrypt(enc)
             )
             self.assertEqual(cleartext, utils.to_string(text))
-
-    def test_decrypt_dict(self):
-        enc = self.project_credentials.encrypt(self.data)
-
-        cleartext = utils.to_string(self.project_credentials.decrypt(enc))
-        self.assertEqual(cleartext, self.data)
 
     def test_decrypt_dict_invalid(self):
         with self.assertRaises(ValueError):
@@ -104,13 +98,6 @@ class TestProjectCredentials(TestCredentials):
                     'ts': 128, 'iv': 'aa', 'ct': 'aa'
                 }
             )
-
-    def test_decrypt_no_iv(self):
-        with self.assertRaises(ValueError):
-            self.project_credentials.decrypt("aa")
-
-        with self.assertRaises(ValueError):
-            self.project_credentials.decrypt("aa", None)
 
 
 class TestKeypair(unittest.TestCase):

--- a/tests/test_keychain.py
+++ b/tests/test_keychain.py
@@ -5,6 +5,7 @@ import os
 import tempfile
 import uuid
 import base64
+import binascii
 import logging
 import unittest
 
@@ -94,6 +95,13 @@ class TestProjectCredentials(TestCredentials):
                 {
                     'cipher': 'aes', 'mode': 'gcm',
                     'ts': 129, 'iv': 'aa', 'ct': 'aa'
+                }
+            )
+        with self.assertRaises((binascii.Error, TypeError)):
+            self.project_credentials.decrypt(
+                {
+                    'cipher': 'aes', 'mode': 'gcm',
+                    'ts': 128, 'iv': 'aa', 'ct': 'aa'
                 }
             )
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -229,6 +229,13 @@ class TestEncryptDecryptAttributes(unittest.TestCase):
         with self.assertRaises(ValueError):
             service.decrypt_attr_value(enc, self.key)
 
+    def test_decrypt_invalid_tag_size(self):
+        enc = service.encrypt_attr_value(self.data, self.key, False)
+        enc['tag'] = enc['tag'][:12]
+
+        with self.assertRaises(ValueError):
+            service.decrypt_attr_value(enc, self.key)
+
 
 class TestKeyWrapUnwrap(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
https://jira.nexgen.neustar.biz/browse/ONEID-534

AES-GCM can be implemented more efficiently with 96-bit IVs. This is also what is required by JOSE for encryption using GCM.

Also removed legacy parameters in ProjectCredentials.decrypt and did some refactoring.